### PR TITLE
NET-100 Fix distribution tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
 
   test-node:
     docker:
-      - image: circleci/node:17
+      - image: circleci/node:16
     working_directory: ~/sylo-ethereum-contracts
     steps:
       - restore_cache:
@@ -49,7 +49,7 @@ jobs:
 
   test-coverage:
     docker:
-      - image: circleci/node:17
+      - image: circleci/node:16
     working_directory: ~/sylo-ethereum-contracts
     steps:
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             - v1-repo-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: test contracts
-          command: npm test
+          command: ITERATIONS=10000 npm test
       - run:
           name: prepare outputs
           command: node ./scripts/parseArtifacts.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
 
   test-node:
     docker:
-      - image: circleci/node:14
+      - image: circleci/node:17
     working_directory: ~/sylo-ethereum-contracts
     steps:
       - restore_cache:
@@ -49,7 +49,7 @@ jobs:
 
   test-coverage:
     docker:
-      - image: circleci/node:14
+      - image: circleci/node:17
     working_directory: ~/sylo-ethereum-contracts
     steps:
       - restore_cache:

--- a/test/staking.ts
+++ b/test/staking.ts
@@ -496,7 +496,9 @@ describe('Staking', () => {
     await directory.addManager(owner);
     await directory.setCurrentDirectory(epochId);
 
-    const iterations = 10000;
+    const iterations = process.env.ITERATIONS ? parseInt(process.env.ITERATIONS) : 1000;
+
+    console.log(`running all equal stake amount distribution test with ${iterations} iterations`);
 
     let expectedResults: Results = {};
     for (let i = 0; i < numAccounts; i++) {
@@ -521,7 +523,9 @@ describe('Staking', () => {
     await directory.addManager(owner);
     await directory.setCurrentDirectory(epochId);
 
-    const iterations = 10000;
+    const iterations = process.env.ITERATIONS ? parseInt(process.env.ITERATIONS) : 1000;
+
+    console.log(`running varied stake amount distribution test with ${iterations} iterations`);
 
     let expectedResults: Results = {};
     for (let i = 0; i < numAccounts; i++) {

--- a/test/staking.ts
+++ b/test/staking.ts
@@ -481,7 +481,7 @@ describe('Staking', () => {
       .to.be.revertedWith("Only managers of this contract can call this function");
   });
 
-  it('should distribute scan results amongst stakees proportionally - all equal [ @skip-on-coverage ]', async () => {
+  it.only('should distribute scan results amongst stakees proportionally - all equal [ @skip-on-coverage ]', async () => {
     const numAccounts = 10;
 
     let totalStake = 0;
@@ -496,7 +496,7 @@ describe('Staking', () => {
     await directory.addManager(owner);
     await directory.setCurrentDirectory(epochId);
 
-    const iterations = 5000;
+    const iterations = 10000;
 
     let expectedResults: Results = {};
     for (let i = 0; i < numAccounts; i++) {
@@ -506,7 +506,7 @@ describe('Staking', () => {
     await testScanResults(iterations, expectedResults);
   }).timeout(0);
 
-  it('should distribute scan results amongst stakees proportionally - varied stake amounts [ @skip-on-coverage ]', async () => {
+  it.only('should distribute scan results amongst stakees proportionally - varied stake amounts [ @skip-on-coverage ]', async () => {
     const numAccounts = 10;
 
     let totalStake = 0;
@@ -521,7 +521,7 @@ describe('Staking', () => {
     await directory.addManager(owner);
     await directory.setCurrentDirectory(epochId);
 
-    const iterations = 5000;
+    const iterations = 10000;
 
     let expectedResults: Results = {};
     for (let i = 0; i < numAccounts; i++) {

--- a/test/staking.ts
+++ b/test/staking.ts
@@ -481,7 +481,7 @@ describe('Staking', () => {
       .to.be.revertedWith("Only managers of this contract can call this function");
   });
 
-  it.only('should distribute scan results amongst stakees proportionally - all equal [ @skip-on-coverage ]', async () => {
+  it('should distribute scan results amongst stakees proportionally - all equal [ @skip-on-coverage ]', async () => {
     const numAccounts = 10;
 
     let totalStake = 0;
@@ -508,7 +508,7 @@ describe('Staking', () => {
     await testScanResults(iterations, expectedResults);
   }).timeout(0);
 
-  it.only('should distribute scan results amongst stakees proportionally - varied stake amounts [ @skip-on-coverage ]', async () => {
+  it('should distribute scan results amongst stakees proportionally - varied stake amounts [ @skip-on-coverage ]', async () => {
     const numAccounts = 10;
 
     let totalStake = 0;


### PR DESCRIPTION
1. Up the iteration count for the distribution tests when running in circle ci. This should lower the chance that the tests will fail.
2. I also was unable to get the tests failing locally, even after running multiple times. This may be due to running node 16 locally, vs running node 14 in the circle ci image, so updated that as well.