### PR TITLE
NET-104 Create channel contract and update scan function

### DIFF
--- a/contracts/Channels.sol
+++ b/contracts/Channels.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+contract Channels is Initializable, OwnableUpgradeable {
+    mapping(address => uint8) public channels;
+
+    event NewChannelUpdated(uint8 newChannel);
+
+    function initialize() external initializer {
+        OwnableUpgradeable.__Ownable_init();
+    }
+
+    function setChannel(uint8 channel) external {
+        channels[msg.sender] = channel;
+    }
+
+    function getChannel() external view returns (uint8) {
+        return channels[msg.sender];
+    }
+}

--- a/contracts/Channels.sol
+++ b/contracts/Channels.sol
@@ -4,19 +4,44 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
+/**
+ * @notice This contract manages Channels for users to
+ * switch node during epoch.
+ *
+ * The channel value will be hashed in the Directory's scan function
+ * together with user's public key and epochId to determine the
+ * node address.
+ */
 contract Channels is Initializable, OwnableUpgradeable {
+    /**
+     * @notice Tracks each user's channel
+     */
     mapping(address => uint8) public channels;
 
+    /**
+     * @notice Display value when setting new channel
+     */
     event NewChannelUpdated(uint8 newChannel);
 
     function initialize() external initializer {
         OwnableUpgradeable.__Ownable_init();
     }
 
+    /**
+     * @notice Call this as a user to set or update your channel.
+     * @param channel The channel value to set (0-48).
+     */
     function setChannel(uint8 channel) external {
+        require(channel <= 48, "Channels cannot be more than 48");
+
         channels[msg.sender] = channel;
+        emit NewChannelUpdated(channel);
     }
 
+    /**
+     * @notice Retrieve the channel associated with the user.
+     * @return The user's channel.
+     */
     function getChannel() external view returns (uint8) {
         return channels[msg.sender];
     }

--- a/test/channels.ts
+++ b/test/channels.ts
@@ -1,0 +1,34 @@
+import { ethers } from "hardhat";
+import { Signer } from "ethers";
+import { Channels } from "../typechain";
+import { assert, expect } from "chai";
+
+describe('Channel', () => {
+  let accounts: Signer[];
+
+  let channels: Channels;
+
+  before(async () => {
+    accounts = await ethers.getSigners();
+  });
+
+  beforeEach(async () => {
+    const Channels = await ethers.getContractFactory("Channels");
+    channels = (await Channels.deploy()) as Channels;
+    await channels.initialize({ from: await accounts[0].getAddress() });
+  });
+
+  it('can set channel', async () => {
+    await expect(channels.setChannel(1))
+      .to.emit(channels, 'NewChannelUpdated')
+      .withArgs(1);
+
+    const channel = await channels.getChannel();
+    assert.equal(channel, 1, "Expected channel to be 1");
+  });
+
+  it('cannot set channel greater than 48', async () => {
+    await expect(channels.setChannel(49))
+      .to.be.revertedWith("Channels cannot be more than 48");
+  });
+});

--- a/test/listings.ts
+++ b/test/listings.ts
@@ -39,6 +39,13 @@ describe('Listing', () => {
     assert.equal(listing.minDelegatedStake.toNumber(), 1, "Expected listing to have correct min delegated stake");
   });
 
+  it('requires default payout percentage to not exceed 100% when initializing', async () => {
+    const Listings = await ethers.getContractFactory("Listings");
+    listings = await Listings.deploy() as Listings;
+    await expect(listings.initialize(10001))
+      .to.be.revertedWith("The payout percentage can not exceed 100 percent");
+  });
+
   it('requires default payout percentage to not exceed 100%', async () => {
     await expect(listings.setDefaultPayoutPercentage(10001))
       .to.be.revertedWith("The payout percentage can not exceed 100 percent");

--- a/test/payments/ticketing.ts
+++ b/test/payments/ticketing.ts
@@ -48,6 +48,18 @@ describe('Ticketing', () => {
     await token.approve(ticketing.address, toSOLOs(10000000));
   });
 
+  it('should fail to initialize because ticket duration is 0', async () => {
+    const TicketingParameters = await ethers.getContractFactory("TicketingParameters");
+    const parameters = await TicketingParameters.deploy() as TicketingParameters;
+    await expect(parameters.initialize(
+      15,
+      BigNumber.from(2).pow(128).sub(1),
+      1000,
+      8000,
+      0))
+      .to.be.revertedWith("Ticket duration cannot be 0");
+  });
+
   it('should be able to set parameters after initialization', async () => {
     await expect(ticketingParameters.setFaceValue(777))
       .to.emit(ticketingParameters, 'FaceValueUpdated')

--- a/test/staking.ts
+++ b/test/staking.ts
@@ -308,6 +308,14 @@ describe('Staking', () => {
       .to.be.revertedWith("Can not join directory without owning minimum amount of stake");
   });
 
+  it('should not be able to join the next epoch more than once', async () => {
+    await stakingManager.addStake(1, owner);
+    await directory.addManager(owner);
+    await directory.joinNextDirectory(owner);
+    await expect(directory.joinNextDirectory(owner))
+      .to.be.revertedWith("Can only join the directory once per epoch");
+  });
+
   it('should be able to get total stake for a stakee', async () => {
     await stakingManager.addStake(100, owner);
     for (let i = 2; i < 10; i++) {
@@ -357,72 +365,10 @@ describe('Staking', () => {
       });
   });
 
-  it('should be able to scan after joining directory', async () => {
-    await stakingManager.addStake(1, owner);
-    await epochsManager.joinNextEpoch();
-
-    await directory.addManager(owner);
-    await directory.setCurrentDirectory(epochId);
-
-    const pk = crypto.randomBytes(32);
-    await directory.scan(pk, epochId, 0);
-  });
-
-  it('should be able to update node address when changing channel in scan', async () => {
-    for (let i = 0; i < 5; i++) {
-      await token.transfer(await accounts[i].getAddress(), 100);
-      await token.connect(accounts[i]).approve(stakingManager.address, 100);
-      await stakingManager.connect(accounts[i]).addStake(1, await accounts[i].getAddress());
-      await epochsManager.connect(accounts[i]).joinNextEpoch();
-    }
-
-    await directory.addManager(owner);
-    await directory.setCurrentDirectory(epochId);
-
-    const pk = crypto.randomBytes(32);
-    const addr1 = await directory.scan(pk, epochId, 0);
-
-    let nodeAddressChanged = false;
-    for (let i = 1; i < 48; i++) {
-      const addr2 = await directory.scan(pk, epochId, i);
-      if (addr1 !== addr2) {
-        nodeAddressChanged = true;
-        break;
-      }
-    }
-
-    assert.isTrue(nodeAddressChanged, "Expected node address to be changed");
-  });
-
-  it('should not be able to join the next epoch more than once', async () => {
-    await stakingManager.addStake(1, owner);
-    await directory.addManager(owner);
-    await directory.joinNextDirectory(owner);
-    await expect(directory.joinNextDirectory(owner))
-      .to.be.revertedWith('Can only join the directory once per epoch');
-  });
-
-  it('should be able to scan empty directory', async () => {
-    await directory.addManager(owner);
-    await directory.setCurrentDirectory(epochId);
-
-    const pk = crypto.randomBytes(32);
-    const address = await directory.scan(pk, epochId, 0);
-
-    assert.equal(
-      address.toString(),
-      '0x0000000000000000000000000000000000000000',
-      "Expected empty directory to scan to zero address"
-    );
-  });
-
   it('should be able to query properties of directory', async () => {
     let expectedTotalStake = 0;
     for (let i = 0; i < accounts.length; i++) {
-      await token.transfer(await accounts[i].getAddress(), 100);
-      await token.connect(accounts[i]).approve(stakingManager.address, 100);
-      await stakingManager.connect(accounts[i]).addStake(1, await accounts[i].getAddress());
-      await epochsManager.connect(accounts[i]).joinNextEpoch();
+      await addStake(i)
 
       expectedTotalStake += 1;
       const stake = await directory.getTotalStakeForStakee(1, await accounts[i].getAddress());
@@ -433,8 +379,7 @@ describe('Staking', () => {
       );
     }
 
-    await directory.addManager(owner);
-    await directory.setCurrentDirectory(epochId);
+    await updateCurrentDirectory(epochId)
 
     const totalStake = await directory.getTotalStake(1);
     assert.equal(
@@ -478,16 +423,83 @@ describe('Staking', () => {
     );
   });
 
-  it('should correctly scan accounts based on their stake proportions in _scan', async () => {
-    for (let i = 0; i < 5; i++) {
-      await token.transfer(await accounts[i].getAddress(), 100);
-      await token.connect(accounts[i]).approve(stakingManager.address, 100);
-      await stakingManager.connect(accounts[i]).addStake(1, await accounts[i].getAddress());
-      await epochsManager.connect(accounts[i]).joinNextEpoch();
-    }
+  it('can not call functions that onlyManager constraint', async () => {
+    await expect(directory.joinNextDirectory(owner))
+      .to.be.revertedWith("Only managers of this contract can call this function");
+  });
+
+  it('should be able to scan after joining directory', async () => {
+    await stakingManager.addStake(1, owner);
+    await epochsManager.joinNextEpoch();
 
     await directory.addManager(owner);
     await directory.setCurrentDirectory(epochId);
+
+    const pk = crypto.randomBytes(32);
+    await directory.scan(pk, epochId, 0);
+  });
+
+  it('should be able to scan empty directory', async () => {
+    await directory.addManager(owner);
+    await directory.setCurrentDirectory(epochId);
+
+    const pk = crypto.randomBytes(32);
+    const address = await directory.scan(pk, epochId, 0);
+
+    assert.equal(
+      address.toString(),
+      '0x0000000000000000000000000000000000000000',
+      "Expected empty directory to scan to zero address"
+    );
+  });
+
+  it('should scan and return different node address when changing channel', async () => {
+    for (let i = 0; i < 5; i++) {
+      await addStake(i)
+    }
+    await updateCurrentDirectory(epochId)
+
+    const pk = crypto.randomBytes(32);
+    const addr1 = await directory.scan(pk, epochId, 0);
+
+    let nodeAddressChanged = false;
+    for (let i = 1; i < 48; i++) {
+      const addr2 = await directory.scan(pk, epochId, i);
+      if (addr1 !== addr2) {
+        nodeAddressChanged = true;
+        break;
+      }
+    }
+
+    assert.isTrue(nodeAddressChanged, "Expected node address to be changed");
+  });
+
+  it('should scan and return the same address for the same epochId', async () => {
+    for (let i = 0; i < 5; i++) {
+      await addStake(i)
+    }
+    await updateCurrentDirectory(epochId);
+
+    const pk = crypto.randomBytes(32);
+    const addr1 = await directory.scan(pk, epochId, 0);
+
+    await epochsManager.initializeEpoch({ from: owner });
+
+    for (let i = 0; i < 5; i++) {
+      await addStake(i)
+    }
+    await updateCurrentDirectory(epochId + 1);
+
+    const addr2 = await directory.scan(pk, epochId, 0);
+
+    assert.equal(addr1, addr2, "Expected to return the same address");
+  });
+
+  it('should correctly scan accounts based on their stake proportions in _scan', async () => {
+    for (let i = 0; i < 5; i++) {
+      await addStake(i)
+    }
+    await updateCurrentDirectory(epochId)
 
     const fifthPoint = BigNumber.from(2).pow(128).sub(1).div(5);
     const points = [
@@ -504,9 +516,16 @@ describe('Staking', () => {
     }
   });
 
-  it('can not call functions that onlyManager constraint', async () => {
-    await expect(directory.joinNextDirectory(owner))
-      .to.be.revertedWith("Only managers of this contract can call this function");
+  it('cannot scan channel greater than 48', async () => {
+    await stakingManager.addStake(1, owner);
+    await epochsManager.joinNextEpoch();
+
+    await directory.addManager(owner);
+    await directory.setCurrentDirectory(epochId);
+
+    const pk = crypto.randomBytes(32);
+    await expect(directory.scan(pk, epochId, 49))
+    .to.be.revertedWith("Only channels 0-48 are supported");;
   });
 
   it('should distribute scan results amongst stakees proportionally in _scan - all equal [ @skip-on-coverage ]', async () => {
@@ -514,15 +533,11 @@ describe('Staking', () => {
 
     let totalStake = 0;
     for (let i = 0; i < numAccounts; i++) {
-      await token.transfer(await accounts[i].getAddress(), 100);
-      await token.connect(accounts[i]).approve(stakingManager.address, 100);
-      await stakingManager.connect(accounts[i]).addStake(1, await accounts[i].getAddress());
-      await epochsManager.connect(accounts[i]).joinNextEpoch();
+      await addStake(i)
       totalStake += 1;
     }
 
-    await directory.addManager(owner);
-    await directory.setCurrentDirectory(epochId);
+    await updateCurrentDirectory(epochId)
 
     const iterations = process.env.ITERATIONS ? parseInt(process.env.ITERATIONS) : 1000;
 
@@ -658,5 +673,19 @@ describe('Staking', () => {
     }
 
     return points;
+  }
+
+  async function addStake(accountNum: number) {
+    await token.transfer(await accounts[accountNum].getAddress(), 100);
+    await token.connect(accounts[accountNum]).approve(stakingManager.address, 100);
+    await stakingManager
+      .connect(accounts[accountNum])
+      .addStake(1, await accounts[accountNum].getAddress());
+    await epochsManager.connect(accounts[accountNum]).joinNextEpoch();
+  }
+
+  async function updateCurrentDirectory(epoch: number) {
+    await directory.addManager(owner);
+    await directory.setCurrentDirectory(epoch);
   }
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,7 +1,7 @@
 import { ethers } from "hardhat";
 import { BigNumber, BigNumberish } from "ethers";
 import { toWei } from 'web3-utils';
-import { Directory, EpochsManager, Listings, RewardsManager, StakingManager, SyloTicketing, TicketingParameters } from '../typechain';
+import { Directory, EpochsManager, Listings, RewardsManager, StakingManager, SyloTicketing, TicketingParameters, Channels } from '../typechain';
 
 type Options = {
   faceValue?: BigNumberish;
@@ -37,6 +37,10 @@ const initializeContracts = async function(deployer: string, tokenAddress: strin
   const Listings = await ethers.getContractFactory("Listings");
   const listings = await Listings.deploy() as Listings;
   await listings.initialize(payoutPercentage, { from: deployer });
+
+  const Channels = await ethers.getContractFactory("Channels");
+  const channels = await Channels.deploy() as Channels;
+  await channels.initialize({ from: deployer });
 
   const TicketingParameters = await ethers.getContractFactory("TicketingParameters");
   const ticketingParameters = await TicketingParameters.deploy() as TicketingParameters;
@@ -109,12 +113,13 @@ const initializeContracts = async function(deployer: string, tokenAddress: strin
 
   return {
     listings,
+    channels,
     ticketing,
     ticketingParameters,
     directory,
     rewardsManager,
     epochsManager,
-    stakingManager
+    stakingManager,
   }
 }
 


### PR DESCRIPTION
Summary of changes:

- Create `Channel` contract to store user's current channel on-chain.
- Update `scan(uint128 point)` to `_scan(uint256 point, uint256 epochId)`
- Create `scan(bytes memory pk, uint256 epochId, uint8 channel)` as an entry method to hash inputs and scan.
- Create `derivePoint` method to hash `public key, current epoch id, and channel` using `keccak256`.
