### PR TITLE
NET-111-fixing-flaky-tests

### DIFF
--- a/test/staking.ts
+++ b/test/staking.ts
@@ -8,7 +8,6 @@ import { assert, expect } from "chai";
 
 // Chi Squared goodness of fit test
 const chi2gof = require('@stdlib/stats/chi2gof');
-const fs = require('fs');
 
 type Results = { [key: string]: number };
 


### PR DESCRIPTION
Fixed flaky tests:
- `should distribute scan results amongst stakees proportionally - all equal`
- `should distribute scan results amongst stakees proportionally - varied stake amounts`

Previous random generation method had a failure rate of 6.44%. New method does not fail.

Test Logs: [output.zip](https://github.com/dn3010/sylo-ethereum-contracts/files/8413828/output.zip)