### PR TITLE
NET-141 Public Endpoint

### DIFF
--- a/contracts/Listings.sol
+++ b/contracts/Listings.sol
@@ -12,8 +12,11 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 contract Listings is Initializable, OwnableUpgradeable {
 
     struct Listing {
-        // MultiAddr to connect to the account
-        string multiAddr;
+        // Public http/s endpoint to retrieve additional metadata
+        // about the node.
+        // The current metadata schema is as follows:
+        //  { name: string, multiaddrs: string[] }
+        string publicEndpoint;
 
         // Percentage of a tickets value that will be rewarded to
         // delegated stakers expressed as a fraction of 10000.
@@ -69,16 +72,17 @@ contract Listings is Initializable, OwnableUpgradeable {
 
     /**
      * @notice Call this as a Node to set or update your Listing entry.
-     * @param multiAddr The libp2p multiAddr of your Node. Essential for
-     * clients to be able to establish a p2p connection.
+     * @param publicEndpoint The public endpoint of your Node. Essential for
+     * clients to be able to acquire additional information, such as the
+     * multiaddr, which is used to establish a p2p connection.
      * @param minDelegatedStake The minimum amount of stake in SOLO that
      * a staker must add when calling StakingManager.addStake.
      */
-    function setListing(string memory multiAddr, uint256 minDelegatedStake) external {
-        require(bytes(multiAddr).length != 0, "Multiaddr string is empty");
+    function setListing(string memory publicEndpoint, uint256 minDelegatedStake) external {
+        require(bytes(publicEndpoint).length != 0, "Multiaddr string is empty");
 
         // TODO Remove defaultPayoutPercentage once epochs are introduced
-        Listing memory listing = Listing(multiAddr, defaultPayoutPercentage, minDelegatedStake, true);
+        Listing memory listing = Listing(publicEndpoint, defaultPayoutPercentage, minDelegatedStake, true);
         listings[msg.sender] = listing;
     }
 

--- a/contracts/Listings.sol
+++ b/contracts/Listings.sol
@@ -79,7 +79,7 @@ contract Listings is Initializable, OwnableUpgradeable {
      * a staker must add when calling StakingManager.addStake.
      */
     function setListing(string memory publicEndpoint, uint256 minDelegatedStake) external {
-        require(bytes(publicEndpoint).length != 0, "Multiaddr string is empty");
+        require(bytes(publicEndpoint).length != 0, "Public endpoint string is empty");
 
         // TODO Remove defaultPayoutPercentage once epochs are introduced
         Listing memory listing = Listing(publicEndpoint, defaultPayoutPercentage, minDelegatedStake, true);

--- a/test/listings.ts
+++ b/test/listings.ts
@@ -35,13 +35,13 @@ describe('Listing', () => {
   });
 
   it('can set listing', async () => {
-    await listings.setListing('0.0.0.0/0', 1);
+    await listings.setListing('http://api', 1);
 
     const listing = await listings.getListing(owner);
 
     assert.equal(
-      listing.multiAddr,
-      '0.0.0.0/0',
+      listing.publicEndpoint,
+      'http://api',
       'Expected listings to have correct address',
     );
     assert.equal(
@@ -59,7 +59,7 @@ describe('Listing', () => {
 
   it('requires listing to not have empty multiaddr string', async () => {
     await expect(listings.setListing('', 1)).to.be.revertedWith(
-      'Multiaddr string is empty',
+      'Public endpoint string is empty',
     );
   });
 });


### PR DESCRIPTION
### Motivation

Instead of nodes posting a multiaddr to connect to with a libp2p client, nodes will instead post a public http endpoint. This endpoint can then be queried for additional information (such as the node's multiaddr).

### Changes

Rename `multiaddr` to`publicEndpoint` in listings struct.