### PR TITLE
NET-267 Combine node reward and staker reward

### DIFF
--- a/contracts/Staking/Directory.sol
+++ b/contracts/Staking/Directory.sol
@@ -95,7 +95,8 @@ contract Directory is Initializable, OwnableUpgradeable, Manageable {
     function joinNextDirectory(address stakee) external onlyManager {
         uint256 managedStake = _stakingManager.getStakeeTotalManagedStake(stakee);
         uint256 stakeReward = _rewardsManager.unclaimedStakeRewards(stakee);
-        uint256 totalStake = managedStake + stakeReward;
+        uint256 nodeReward = _rewardsManager.unclaimedNodeRewards(stakee);
+        uint256 totalStake = managedStake + stakeReward + nodeReward;
         require(totalStake > 0, "Can not join directory for next epoch without any stake");
         require(
             _stakingManager.checkMinimumStakeProportion(stakee),


### PR DESCRIPTION
TODO: Rebase this branch after NET-269 is merged.

When a node redeem’s a ticket, a portion of the reward is given to the stakers (including the node’s stake), and another portion is given directly to the node’s account as sort of a fee for running the node hardware.

Additionally, rewards are considered as part of a node’s stake. however, only the staking reward is is added to the node’s stake, and not the fee reward. Also, the node operator would see two types of rewards, the staking reward and the fee reward.

For simplicity, it was decided that the node staking and fee reward should essentially be combined. Meaning that both rewards are added to the node’s stake on each redemption, and also for reward calculation, the stake reward should be calculated first then the fee reward should be added on top of it.