### PR TITLE
NET-352 remove minDelegatedStake from registries contract

### DIFF
--- a/contracts/Registries.sol
+++ b/contracts/Registries.sol
@@ -36,9 +36,6 @@ contract Registries is Initializable, OwnableUpgradeable {
         // This value is currently locked to the default payout percentage
         // until epochs are implemented.
         uint16 payoutPercentage;
-        // The minimum amount of stake that is required to
-        // add delegated stake against this node
-        uint256 minDelegatedStake;
     }
 
     /**
@@ -114,10 +111,8 @@ contract Registries is Initializable, OwnableUpgradeable {
      * @param publicEndpoint The public endpoint of your Node. Essential for
      * clients to be able to retrieve additional information, such as
      * an address to establish a p2p connection.
-     * @param minDelegatedStake The minimum amount of stake in SOLO that
-     * a staker must add when calling StakingManager.addStake.
      */
-    function register(string memory publicEndpoint, uint256 minDelegatedStake) external {
+    function register(string memory publicEndpoint) external {
         require(bytes(publicEndpoint).length != 0, "Public endpoint can not be empty");
 
         // This is the nodes first registration
@@ -126,7 +121,6 @@ contract Registries is Initializable, OwnableUpgradeable {
         }
 
         registries[msg.sender].publicEndpoint = publicEndpoint;
-        registries[msg.sender].minDelegatedStake = minDelegatedStake;
     }
 
     function setSeekerAccount(

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -273,11 +273,10 @@ calculating the distribution more efficient.
 Every Node must also have a `Registry` entry. The entry holds various network
 parameters which are configured by Nodes themselves.
 
-| Field             | Description                                                                                                                                                                                                          |
-| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| multiAddr         | The libp2p multi address of the Node. This is needed for clients to connect to their Node. Nodes should take care to ensure this value is correct and up to date                                                     |
-| payoutPercentage  | Percentage of a redeemed tickets value that will be paid out to the Node's delegated stakers. **This value is currently unused and is superseded by the _defaultPayoutPercentage_ network parameter for phase two**. |
-| minDelegatedStake | The minimum amount of stake a delegated staker must put forth                                                                                                                                                        |
+| Field            | Description                                                                                                                                                                                                          |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| multiAddr        | The libp2p multi address of the Node. This is needed for clients to connect to their Node. Nodes should take care to ensure this value is correct and up to date                                                     |
+| payoutPercentage | Percentage of a redeemed tickets value that will be paid out to the Node's delegated stakers. **This value is currently unused and is superseded by the _defaultPayoutPercentage_ network parameter for phase two**. |
 
 ### Functions
 
@@ -293,10 +292,9 @@ lifetime of the Sylo Network.
 Nodes are required to set their `Registry` entry to be able to stake and redeem
 tickets.
 
-| Param             | Description                                   |
-| ----------------- | --------------------------------------------- |
-| multiAddr         | Sets the multi addr for the Node              |
-| minDelegatedStake | Sets the minimum delegated stake for the Node |
+| Param     | Description                      |
+| --------- | -------------------------------- |
+| multiAddr | Sets the multi addr for the Node |
 
 ---
 

--- a/test/payments/ticketing.ts
+++ b/test/payments/ticketing.ts
@@ -1725,7 +1725,7 @@ describe('Ticketing', () => {
 
   it('returns 0 winning probability if ticket has expired', async () => {
     await stakingManager.addStake(toSOLOs(1), owner);
-    await registries.register('0.0.0.0/0', 1);
+    await registries.register('0.0.0.0/0');
 
     const alice = Wallet.createRandom();
 

--- a/test/registries.ts
+++ b/test/registries.ts
@@ -50,7 +50,7 @@ describe('Registries', () => {
   });
 
   it('can set registry', async () => {
-    await registries.register('http://api', 1);
+    await registries.register('http://api');
 
     const registry = await registries.getRegistry(owner);
 
@@ -59,16 +59,11 @@ describe('Registries', () => {
       'http://api',
       'Expected registries to have correct address',
     );
-    assert.equal(
-      registry.minDelegatedStake.toNumber(),
-      1,
-      'Expected registry to have correct min delegated stake',
-    );
   });
 
   it('can retrieve all registered nodes', async () => {
-    await registries.register('http://api', 1);
-    await registries.connect(accounts[1]).register('http://api', 1);
+    await registries.register('http://api');
+    await registries.connect(accounts[1]).register('http://api');
 
     const nodes = await registries.getNodes();
 
@@ -79,8 +74,8 @@ describe('Registries', () => {
   });
 
   it('can query total number of registered nodes', async () => {
-    await registries.register('http://api', 1);
-    await registries.connect(accounts[1]).register('http://api', 1);
+    await registries.register('http://api');
+    await registries.connect(accounts[1]).register('http://api');
 
     const n = await registries.getTotalNodes();
 
@@ -91,7 +86,7 @@ describe('Registries', () => {
     const addresses = await Promise.all(accounts.map(a => a.getAddress()));
 
     for (let i = 0; i < 20; i++) {
-      await registries.connect(accounts[i]).register(`http://api/${i}`, 1);
+      await registries.connect(accounts[i]).register(`http://api/${i}`);
     }
 
     const result = await registries.getRegistries(0, 20);
@@ -116,7 +111,7 @@ describe('Registries', () => {
     const addresses = await Promise.all(accounts.map(a => a.getAddress()));
 
     for (let i = 0; i < 20; i++) {
-      await registries.connect(accounts[i]).register(`http://api/${i}`, 1);
+      await registries.connect(accounts[i]).register(`http://api/${i}`);
     }
 
     const result = await registries.getRegistries(5, 10);
@@ -273,7 +268,7 @@ describe('Registries', () => {
   });
 
   it('requires registry to not have empty public endpoint string', async () => {
-    await expect(registries.register('', 1)).to.be.revertedWith(
+    await expect(registries.register('')).to.be.revertedWith(
       'Public endpoint can not be empty',
     );
   });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -176,7 +176,7 @@ async function setSeekerRegistry(
 
   const signature = await seekerAccount.signMessage(proofMessage);
 
-  await registries.connect(account).register('0.0.0.0/0', 1);
+  await registries.connect(account).register('0.0.0.0/0');
 
   await registries
     .connect(account)


### PR DESCRIPTION
## Motivation
The minDelegatedStake field is intended to be configured by nodes to set a minimum Sylo amount that a delegate must provide when staking. It was decided that we did not need to use this value for phase 2, as its main purpose is to prevent the list of delegated stakers being too long, which could have an implication on gas costs, but this no longer applies.

However the field still exists in the Registry, and is still passed in when calling register. We should remove this field from the contract for phase 2 as it creates unnecessary confusion.

## Summary of changes
- Removed the minDelegatedStake field from the Registry struct within the Registries contract
- Removed the minDelegatedStake parameter within the register function call
- Amended the test cases by removing the now extra parameter

### Documentation

- [X] Updated the readme documents (`README.md` etc.)
- [X] Updated `CHANGELOG.md` with new items at top of list

### Local Build

- [X] Execute npm run test

### Jira
- [X] PR name matches Jira task `NET-XXX`
- [X] Branch name matches Jira task `NET-XXX`

### GitHub

- [X] Target branch has been set correctly
- [X] PR has been rebased onto target branch
- [X] Author has performed a self-review of the code
- [X] Removed the WIP message from the top of this PR