### PR TITLE
Net 396 update signing message

### DIFF
--- a/contracts/Registries.sol
+++ b/contracts/Registries.sol
@@ -16,9 +16,6 @@ import "./ECDSA.sol";
 contract Registries is Initializable, OwnableUpgradeable {
     using ECDSA for bytes32;
 
-    // string public constant SEEKER_OWNERSHIP_PREFIX =
-    //     "This message allows your seeker to be used to operate your node.";
-
     struct Registry {
         // Public http/s endpoint to retrieve additional metadata
         // about the node.

--- a/test/registries.ts
+++ b/test/registries.ts
@@ -311,4 +311,24 @@ describe('Registries', () => {
     expect(regoSeekerAccountOne.seekerId).to.equal(0);
     expect(regoSeekerAccountTwo.seekerId).is.equal(tokenID);
   });
+
+  it.only('Has the correct prefix message', async () => {
+    const account = accounts[0];
+
+    const seekerAccount = accounts[1];
+
+    const tokenID = 100; // Seeker ID
+
+    await utils.setSeekerRegistry(
+      registries,
+      seekers,
+      account,
+      seekerAccount,
+      tokenID,
+    );
+
+    const prefix = await registries.getPrefix();
+
+    console.log(prefix);
+  });
 });

--- a/test/registries.ts
+++ b/test/registries.ts
@@ -312,7 +312,7 @@ describe('Registries', () => {
     expect(regoSeekerAccountTwo.seekerId).is.equal(tokenID);
   });
 
-  it.only('Has the correct prefix message', async () => {
+  it('Has the correct prefix message', async () => {
     const account = accounts[0];
 
     const seekerAccount = accounts[1];


### PR DESCRIPTION
## Todo
I expect that some renaming will need to be done and or removing of the added test case within the registries typescript file

- [X] add some items to the todo list

## Motivation
The current message shown to the user is boring, and also does not do a good enough job of explaining the purpose of signing the message. The marketing has given us an updated message to use which is not written into the Registries contract.

## Summary of changes
- Removed old seeker ownership prefix with new variable to hold the seeker ownership message.
- Created function to update ownership message whenever the seeker registry is set, important for the block number
-  Wrote a test case to check the block number would be correct and display the message

## Checklist

<!-- If not applicable to this PR, the item can be checked, crossed out, or removed. -->

### Local Build

- [X] Ran the test suite locally (`npm test`)

### Jira
- [X] PR name matches Jira task `NET-XXX`
- [X] Branch name matches Jira task `NET-XXX`

### GitHub

- [X] Target branch has been set correctly
- [X] PR has been rebased onto target branch
- [X] Author has performed a self-review of the code
- [X] Removed the WIP message from the top of this PR
