### PR TITLE
Net 447 (SLP-03) Adjust ticket block check

### DIFF
--- a/contracts/Payments/Ticketing.sol
+++ b/contracts/Payments/Ticketing.sol
@@ -225,9 +225,8 @@ contract SyloTicketing is Initializable, OwnableUpgradeable {
         EpochsManager.Epoch memory epoch = _epochsManager.getEpoch(ticket.epochId);
         require(epoch.startBlock > 0, "Ticket's associated epoch does not exist");
         require(
-            ticket.generationBlock >= epoch.startBlock &&
-                (epoch.endBlock > 0 ? ticket.generationBlock < epoch.endBlock : true),
-            "This ticket was not generated during it's associated epoch"
+            ticket.generationBlock <= block.number,
+            "The ticket cannot be generated for a future block"
         );
 
         bytes32 ticketHash = getTicketHash(ticket);

--- a/contracts/Payments/Ticketing.sol
+++ b/contracts/Payments/Ticketing.sol
@@ -223,7 +223,6 @@ contract SyloTicketing is Initializable, OwnableUpgradeable {
         bytes memory sig
     ) external {
         EpochsManager.Epoch memory epoch = _epochsManager.getEpoch(ticket.epochId);
-        require(epoch.startBlock > 0, "Ticket's associated epoch does not exist");
         require(
             ticket.generationBlock <= block.number,
             "The ticket cannot be generated for a future block"

--- a/test/payments/ticketing.ts
+++ b/test/payments/ticketing.ts
@@ -414,9 +414,7 @@ describe('Ticketing', () => {
   it('can not redeem ticket if associated epoch does not exist', async () => {
     const alice = Wallet.createRandom();
     const { ticket, senderRand, redeemerRand, signature } =
-      await createWinningTicket(alice, owner);
-
-    ticket.epochId = 1;
+      await createWinningTicket(alice, owner, 1);
 
     await expect(
       ticketing.redeem(ticket, senderRand, redeemerRand, signature),

--- a/test/payments/ticketing.ts
+++ b/test/payments/ticketing.ts
@@ -434,20 +434,18 @@ describe('Ticketing', () => {
     ).to.be.revertedWith("Ticket's associated epoch does not exist");
   });
 
-  it('can not redeem ticket if not generated during associated epoch', async () => {
+  it('can not redeem ticket if generated for a future block', async () => {
     await epochsManager.initializeEpoch();
 
     const alice = Wallet.createRandom();
     const { ticket, senderRand, redeemerRand, signature } =
       await createWinningTicket(alice, owner);
 
-    const updatedTicket = { ...ticket, generationBlock: 1 };
+    const updatedTicket = { ...ticket, generationBlock: 100000 };
 
     await expect(
       ticketing.redeem(updatedTicket, senderRand, redeemerRand, signature),
-    ).to.be.revertedWith(
-      "This ticket was not generated during it's associated epoch",
-    );
+    ).to.be.revertedWith('The ticket cannot be generated for a future block');
   });
 
   it('can not calculate winning probablility if not generated during associated epoch', async () => {


### PR DESCRIPTION
## Motivation

The audit noted that it was possible for a ticket to be redeemed with a generation block greater than the current epoch's end block.

This PR prevents that by additionally checking if the ticket generation block is less than or equal to than the current block.

## Summary of Changes

- Add additional check for ticket generation block
- Remove require check that the ticket generation block is within the current epoch in the `redeem` function. This is because we also perform the same check in `calculateWinningProbability`, so it is unnecessary to do here as well.