### PR TITLE
NET-449 (SLP-05) Use SafeCast lib to avoid integer overflow

### DIFF
--- a/contracts/Payments/Ticketing.sol
+++ b/contracts/Payments/Ticketing.sol
@@ -11,6 +11,7 @@ import "./Ticketing/RewardsManager.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 /**
  * @notice The SyloTicketing contract manages the Probabilistic
@@ -396,7 +397,7 @@ contract SyloTicketing is Initializable, OwnableUpgradeable {
 
         // calculate the remaining probability by subtracting the decayed probability
         // from the base
-        return epoch.baseLiveWinProb - uint128(decayedProbability);
+        return epoch.baseLiveWinProb - SafeCast.toUint128(decayedProbability);
     }
 
     /**

--- a/contracts/Payments/Ticketing/RewardsManager.sol
+++ b/contracts/Payments/Ticketing/RewardsManager.sol
@@ -8,6 +8,7 @@ import "../../Utils.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "abdk-libraries-solidity/ABDKMath64x64.sol";
 
 /**
@@ -287,7 +288,7 @@ contract RewardsManager is Initializable, OwnableUpgradeable, Manageable {
         }
 
         uint256 stakersReward = SyloUtils.percOf(
-            uint128(amount),
+            SafeCast.toUint128(amount),
             currentEpoch.defaultPayoutPercentage
         );
 

--- a/contracts/Staking/Directory.sol
+++ b/contracts/Staking/Directory.sol
@@ -8,6 +8,7 @@ import "../Manageable.sol";
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 /**
  * @notice The Directory contract constructs and manages a structure holding the current stakes,
@@ -98,7 +99,7 @@ contract Directory is Initializable, OwnableUpgradeable, Manageable {
 
         uint256 currentStake = _stakingManager.getCurrentStakerAmount(stakee, stakee);
         uint16 ownedStakeProportion = SyloUtils.asPerc(
-            uint128(currentStake),
+            SafeCast.toUint128(currentStake),
             totalStake
         );
 

--- a/contracts/Staking/Manager.sol
+++ b/contracts/Staking/Manager.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "../Token.sol";
 import "../Payments/Ticketing/RewardsManager.sol";
 import "../Epochs/Manager.sol";
@@ -327,7 +328,7 @@ contract StakingManager is Initializable, OwnableUpgradeable {
 
         uint256 currentlyOwnedStake = stake.stakeEntries[stakee].amount;
         uint16 ownedStakeProportion = SyloUtils.asPerc(
-            uint128(currentlyOwnedStake),
+            SafeCast.toUint128(currentlyOwnedStake),
             stake.totalManagedStake
         );
 

--- a/contracts/Utils.sol
+++ b/contracts/Utils.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
+import "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
 library SyloUtils {
     /**
      * @dev Percentages are expressed as a ratio where 10000 is the denominator.
@@ -27,6 +29,6 @@ library SyloUtils {
      * @return The percentage, as a ratio of 10000.
      */
     function asPerc(uint128 numerator, uint256 denominator) internal pure returns (uint16) {
-        return uint16((uint256(numerator) * PERCENTAGE_DENOMINATOR) / denominator);
+        return SafeCast.toUint16((uint256(numerator) * PERCENTAGE_DENOMINATOR) / denominator);
     }
 }


### PR DESCRIPTION
## Motivation

We perform integer down casts throughout the contract code base. These casts are unsafe as if the value is larger than the maximum value we are casting, then the behaviour of the contract will be unpredictable.

We can use the `SafeCast` which will explicitly throw an error if the value exceeds the maximum. This will prevent unexpected behaviour from happening.

## Summary of Changes

- Replace any integer casts with the `toX` form from the SafeCast lib