### PR TITLE
NET-450 (SLP-06) Improve seeker account signatures

### DIFF
--- a/deploy/00_deploy_phase_two.ts
+++ b/deploy/00_deploy_phase_two.ts
@@ -122,11 +122,7 @@ async function deployPhaseTwoContracts(
   logDeployment('Directory', directory.address);
 
   await registries
-    .initialize(
-      config.Seekers,
-      config.Registries.defaultPayoutPercentage,
-      config.Registries.proofDuration,
-    )
+    .initialize(config.Seekers, config.Registries.defaultPayoutPercentage)
     .then(tx => tx.wait());
 
   console.log('Initialized registries');

--- a/deploy/genesis.config.ts
+++ b/deploy/genesis.config.ts
@@ -14,7 +14,6 @@ type ContractParameters = {
 
   Registries: {
     defaultPayoutPercentage: number;
-    proofDuration: number;
   };
 
   TicketingParameters: {
@@ -60,7 +59,6 @@ const GenesisParameters: ContractParameters = {
 
   Registries: {
     defaultPayoutPercentage: 5000,
-    proofDuration: 100,
   },
 
   TicketingParameters: {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -11,6 +11,7 @@ import {
   TicketingParameters,
   TestSeekers,
 } from '../typechain';
+import { randomBytes } from 'crypto';
 
 type Options = {
   faceValue?: BigNumberish;
@@ -60,7 +61,7 @@ const initializeContracts = async function (
 
   const RegistriesFactory = await ethers.getContractFactory('Registries');
   const registries = await RegistriesFactory.deploy();
-  await registries.initialize(seekers.address, payoutPercentage, 100, {
+  await registries.initialize(seekers.address, payoutPercentage, {
     from: deployer,
   });
 
@@ -168,13 +169,13 @@ async function setSeekerRegistry(
     await seekers.mint(await seekerAccount.getAddress(), tokenId);
   }
 
-  const block = await ethers.provider.getBlockNumber();
+  const nonce = randomBytes(32);
 
   const accountAddress = await account.getAddress();
   const proofMessage = await registries.getProofMessage(
     tokenId,
     accountAddress,
-    block,
+    nonce,
   );
 
   const signature = await seekerAccount.signMessage(
@@ -188,7 +189,7 @@ async function setSeekerRegistry(
     .setSeekerAccount(
       await seekerAccount.getAddress(),
       tokenId,
-      block,
+      nonce,
       signature,
     );
 }


### PR DESCRIPTION
## Motivation

Currently we validate that seeker signatures are submitted within a `proofDuration` time frame. This is to prevent the signature from being reused at a later date. This approach is a remnant of when we were relying on an external Oracle to validate the Seeker proof. This is no longer necessary and we can now just store and use a nonce with each signature to ensure that each one is unique.

## Summary of Changes

- Replace `proofDuration` with a `nonce` in the signature message
- Track nonces in storage to prevent reuse