### PR TITLE
NET-451 (SLP-07) Improve hashing of sender and redeemer rands

### DIFF
--- a/contracts/Payments/Ticketing.sol
+++ b/contracts/Payments/Ticketing.sol
@@ -312,13 +312,13 @@ contract SyloTicketing is Initializable, OwnableUpgradeable {
         // validate that the sender's random number has been revealed to
         // the redeemer
         require(
-            keccak256(abi.encodePacked(senderRand)) == ticket.senderCommit,
+            createCommit(ticket.generationBlock, senderRand) == ticket.senderCommit,
             "Hash of senderRand doesn't match senderRandHash"
         );
 
         // validate the redeemer has knowledge of the redeemer rand
         require(
-            keccak256(abi.encodePacked(redeemerRand)) == ticket.redeemerCommit,
+            createCommit(ticket.generationBlock, redeemerRand) == ticket.redeemerCommit,
             "Hash of redeemerRand doesn't match redeemerRandHash"
         );
 
@@ -328,6 +328,14 @@ contract SyloTicketing is Initializable, OwnableUpgradeable {
         );
 
         require(isWinningTicket(sig, ticket, senderRand, redeemerRand), "Ticket is not a winner");
+    }
+
+    function createCommit(uint256 generationBlock, uint256 rand)
+        public
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(keccak256(abi.encodePacked(generationBlock, rand))));
     }
 
     function getDeposit(address account) private view returns (Deposit storage) {


### PR DESCRIPTION
## Motivation

We hash random integers for use as the sender and redeemer commits. The audit identified this as not being secure enough, and suggested we should double hash and use a salt to improve the hash security.

## Summary of Changes

- Modify the commit creation to use the ticket generation block as a salt, and perform `keccak256` twice.