### PR TITLE
NET 454 (SLP-11) Verify transfer call

### DIFF
--- a/contracts/Payments/Ticketing.sol
+++ b/contracts/Payments/Ticketing.sol
@@ -9,6 +9,7 @@ import "../Utils.sol";
 import "../Epochs/Manager.sol";
 import "./Ticketing/RewardsManager.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
@@ -126,7 +127,7 @@ contract SyloTicketing is Initializable, OwnableUpgradeable {
 
         deposit.escrow += amount;
 
-        _token.transferFrom(msg.sender, address(this), amount);
+        SafeERC20.safeTransferFrom(_token, msg.sender, address(this), amount);
     }
 
     /**
@@ -142,7 +143,7 @@ contract SyloTicketing is Initializable, OwnableUpgradeable {
 
         deposit.penalty += amount;
 
-        _token.transferFrom(msg.sender, address(this), amount);
+        SafeERC20.safeTransferFrom(_token, msg.sender, address(this), amount);
     }
 
     /**
@@ -200,7 +201,7 @@ contract SyloTicketing is Initializable, OwnableUpgradeable {
         // Re-lock so if more funds are deposited they must be unlocked again
         deposit.unlockAt = 0;
 
-        _token.transfer(account, amount);
+        SafeERC20.safeTransfer(_token, account, amount);
     }
 
     /**
@@ -266,7 +267,11 @@ contract SyloTicketing is Initializable, OwnableUpgradeable {
         if (epoch.faceValue > deposit.escrow) {
             amount = deposit.escrow;
             incrementRewardPool(ticket.redeemer, deposit, amount);
-            _token.transfer(address(0x000000000000000000000000000000000000dEaD), deposit.penalty);
+            SafeERC20.safeTransfer(
+                _token,
+                address(0x000000000000000000000000000000000000dEaD),
+                deposit.penalty
+            );
 
             deposit.penalty = 0;
         } else {
@@ -434,7 +439,7 @@ contract SyloTicketing is Initializable, OwnableUpgradeable {
     ) internal {
         deposit.escrow = deposit.escrow - amount;
 
-        _token.transfer(address(_rewardsManager), amount);
+        SafeERC20.safeTransfer(_token, address(_rewardsManager), amount);
         _rewardsManager.incrementRewardPool(stakee, amount);
     }
 }

--- a/contracts/Payments/Ticketing/RewardsManager.sol
+++ b/contracts/Payments/Ticketing/RewardsManager.sol
@@ -6,7 +6,7 @@ import "../../Staking/Manager.sol";
 import "../../Epochs/Manager.sol";
 import "../../Utils.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "abdk-libraries-solidity/ABDKMath64x64.sol";
@@ -502,7 +502,7 @@ contract RewardsManager is Initializable, Manageable {
 
         updateLastClaim(stakee, msg.sender);
 
-        _token.transfer(msg.sender, totalClaim);
+        SafeERC20.safeTransfer(_token, msg.sender, totalClaim);
 
         return totalClaim;
     }

--- a/contracts/Staking/Manager.sol
+++ b/contracts/Staking/Manager.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
@@ -141,7 +142,7 @@ contract StakingManager is Initializable, OwnableUpgradeable {
      */
     function addStake(uint256 amount, address stakee) external {
         addStake_(amount, stakee);
-        _token.transferFrom(msg.sender, address(this), amount);
+        SafeERC20.safeTransferFrom(_token, msg.sender, address(this), amount);
     }
 
     function addStake_(uint256 amount, address stakee) internal {
@@ -238,7 +239,7 @@ contract StakingManager is Initializable, OwnableUpgradeable {
 
         delete unlockings[key];
 
-        _token.transfer(msg.sender, amount);
+        SafeERC20.safeTransfer(_token, msg.sender, amount);
     }
 
     /**


### PR DESCRIPTION
## Motivation

The ERC20 `transfer` and `transferFrom` return `true` when those calls are successful. The contracts should verify those results to prevent unexpected behaviour.

## Summary of Changes

- Use `SafeERC20` for all `transfer` and `transferFrom` calls to verify their execution