### PR TITLE
NET-459 (SLP-16) Add event index

### DIFF
--- a/contracts/Epochs/Manager.sol
+++ b/contracts/Epochs/Manager.sol
@@ -33,7 +33,7 @@ contract EpochsManager is Initializable, OwnableUpgradeable {
         uint16 decayRate;
     }
 
-    event EpochJoined(uint256 epochId, address node, uint256 seekerId);
+    event EpochJoined(uint256 indexed epochId, address indexed node, uint256 indexed seekerId);
 
     Directory public _directory;
 
@@ -70,7 +70,7 @@ contract EpochsManager is Initializable, OwnableUpgradeable {
      */
     mapping(uint256 => Epoch) public epochs;
 
-    event NewEpoch(uint256 epochId);
+    event NewEpoch(uint256 indexed epochId);
 
     function initialize(
         IERC721 rootSeekers,

--- a/contracts/Payments/Ticketing.sol
+++ b/contracts/Payments/Ticketing.sol
@@ -42,9 +42,9 @@ contract SyloTicketing is Initializable, OwnableUpgradeable {
     }
 
     event Redemption(
-        uint256 epochId,
-        address sender,
-        address redeemer,
+        uint256 indexed epochId,
+        address indexed sender,
+        address indexed redeemer,
         uint256 generationBlock,
         uint256 amount
     );

--- a/contracts/Staking/Directory.sol
+++ b/contracts/Staking/Directory.sol
@@ -38,7 +38,7 @@ contract Directory is Initializable, Manageable {
         uint256 totalStake;
     }
 
-    event CurrentDirectoryUpdated(uint256 currentDirectory);
+    event CurrentDirectoryUpdated(uint256 indexed currentDirectory);
 
     /**
      * @notice The epoch ID of the current directory.


### PR DESCRIPTION
Event indexing of smart contracts can be used to filter during the querying of events. This can be very useful when making dApps or in the off-chain processing of the events in our contract, as it allows filtering by specific addresses, making it much easier for developers to query the results of the invocations.

It could be convenient to review the Sylo Project to ensure that all the events have the necessary indexes for the correct functioning of the possible dApps. Addresses are usually the best argument to filter an event.