### PR TITLE
NET-463 (SLP-20) Validate input

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -3,4 +3,5 @@ module.exports = {
     grep: '@skip-on-coverage', // Find everything with this tag
     invert: true, // Run the grep's inverse set.
   },
+  skipFiles: ['/interfaces', '/mocks'],
 };

--- a/contracts/Registries.sol
+++ b/contracts/Registries.sol
@@ -19,8 +19,6 @@ import "./interfaces/IRegistries.sol";
 contract Registries is IRegistries, Initializable, Ownable2StepUpgradeable, IERC165 {
     using ECDSA for bytes32;
 
-    uint256 private constant MAX_SEEKER_ID = 47894;
-
     /**
      * @notice ERC721 contract for bridged Seekers. Used for verifying ownership
      * of a seeker.
@@ -65,7 +63,6 @@ contract Registries is IRegistries, Initializable, Ownable2StepUpgradeable, IERC
 
     event DefaultPayoutPercentageUpdated(uint16 defaultPayoutPercentage);
 
-    error SeekerIdOutOfRange();
     error NonceCannotBeReused();
     error EndMustBeGreaterThanStart();
     error PercentageCannotExceed10000();
@@ -76,8 +73,6 @@ contract Registries is IRegistries, Initializable, Ownable2StepUpgradeable, IERC
     error RootSeekersCannotBeZeroAddress();
     error SeekerAccountCannotBeZeroAddress();
     error EndCannotExceedNumberOfNodes(uint256 nodeLength);
-
-    error Test(bytes4 id);
 
     function initialize(
         IERC721 rootSeekers,
@@ -146,9 +141,6 @@ contract Registries is IRegistries, Initializable, Ownable2StepUpgradeable, IERC
     ) external {
         if (seekerAccount == address(0)) {
             revert SeekerAccountCannotBeZeroAddress();
-        }
-        if (seekerId > MAX_SEEKER_ID) {
-            revert SeekerIdOutOfRange();
         }
         if (signatureNonces[nonce] != address(0)) {
             revert NonceCannotBeReused();

--- a/contracts/interfaces/IRegistries.sol
+++ b/contracts/interfaces/IRegistries.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.18;
+
+interface IRegistries {
+    struct Registry {
+        // Percentage of a tickets value that will be rewarded to
+        // delegated stakers expressed as a fraction of 10000.
+        // This value is currently locked to the default payout percentage
+        // until epochs are implemented.
+        uint16 payoutPercentage;
+        // Public http/s endpoint to retrieve additional metadata
+        // about the node.
+        // The current metadata schema is as follows:
+        //  { name: string, multiaddrs: string[] }
+        string publicEndpoint;
+        // The account which owns a seeker that will be used to
+        // operate the Node for this registry.
+        address seekerAccount;
+        // The id of the seeker used to operate the node. The owner
+        // of this id should be the seeker account.
+        uint256 seekerId;
+    }
+
+    function register(string calldata publicEndpoint) external;
+
+    function setDefaultPayoutPercentage(uint16 _defaultPayoutPercentage) external;
+
+    function setSeekerAccount(
+        address seekerAccount,
+        uint256 seekerId,
+        bytes32 nonce,
+        bytes calldata signature
+    ) external;
+
+    function revokeSeekerAccount(address node) external;
+
+    function getRegistry(address account) external view returns (Registry memory);
+
+    function getNodes() external view returns (address[] memory);
+
+    function getRegistries(
+        uint256 start,
+        uint256 end
+    ) external view returns (address[] memory, Registry[] memory);
+
+    function getTotalNodes() external view returns (uint256);
+}

--- a/contracts/interfaces/epochs/IEpochsManager.sol
+++ b/contracts/interfaces/epochs/IEpochsManager.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.18;
+
+interface IEpochsManager {
+    /**
+     * @dev This struct will hold all network parameters that will be static
+     * for the entire epoch. This value will be stored in a mapping, where the
+     * key is the current epoch id.
+     */
+    struct Epoch {
+        // time related variables
+        uint256 startBlock; // Block the epoch was initialized
+        uint256 duration; // Minimum time epoch will be alive measured in number of blocks
+        uint256 endBlock; // Block the epoch ended (and when the next epoch was initialized)
+        // Zero here represents the epoch has not yet ended.
+
+        // registry variables
+        uint16 defaultPayoutPercentage;
+        // ticketing variables
+        uint16 decayRate;
+        uint256 faceValue;
+        uint128 baseLiveWinProb;
+        uint128 expiredWinProb;
+        uint256 ticketDuration;
+    }
+
+    function initializeEpoch() external returns (uint256);
+
+    function setEpochDuration(uint256 _epochDuration) external;
+
+    function getCurrentActiveEpoch() external view returns (uint256, Epoch memory);
+
+    function joinNextEpoch() external;
+
+    function getEpoch(uint256 epochId) external view returns (Epoch memory);
+
+    function getNextEpochId() external view returns (uint256);
+}

--- a/contracts/interfaces/payments/ISyloTicketing.sol
+++ b/contracts/interfaces/payments/ISyloTicketing.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.18;
+
+interface ISyloTicketing {
+    struct Deposit {
+        uint256 escrow; // Balance of users escrow
+        uint256 penalty; // Balance of users penalty
+        uint256 unlockAt; // Block number a user can withdraw their balances
+    }
+
+    struct Ticket {
+        uint256 epochId; // The epoch this ticket is associated with
+        address sender; // Address of the ticket sender
+        address redeemer; // Address of the intended recipient
+        uint256 generationBlock; // Block number the ticket was generated
+        bytes32 senderCommit; // Hash of the secret random number of the sender
+        bytes32 redeemerCommit; // Hash of the secret random number of the redeemer
+    }
+
+    function setUnlockDuration(uint256 _unlockDuration) external;
+
+    function depositEscrow(uint256 amount, address account) external;
+
+    function depositPenalty(uint256 amount, address account) external;
+
+    function unlockDeposits() external returns (uint256);
+
+    function lockDeposits() external;
+
+    function withdraw() external;
+
+    function redeem(
+        Ticket calldata ticket,
+        uint256 senderRand,
+        uint256 redeemerRand,
+        bytes calldata sig
+    ) external;
+}

--- a/contracts/interfaces/payments/ticketing/IRewardsManager.sol
+++ b/contracts/interfaces/payments/ticketing/IRewardsManager.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.18;
+
+interface IRewardsManager {
+    /**
+     * @dev This type will hold the necessary information for delegated stakers
+     * to make reward claims against their Node. Every Node will initialize
+     * and store a new Reward Pool for each epoch they participate in.
+     */
+    struct RewardPool {
+        // Tracks the balance of the reward pool owed to the stakers
+        uint256 stakersRewardTotal;
+        // Tracks the block number this reward pool was initialized
+        uint256 initializedAt;
+        // The total active stake for the node for will be the sum of the
+        // stakes owned by its delegators and the node's own stake.
+        uint256 totalActiveStake;
+        // track the cumulative reward factor as of the time the first ticket
+        // for this pool was redeemed
+        int128 initialCumulativeRewardFactor;
+    }
+
+    struct LastClaim {
+        // The epoch the claim was made.
+        uint256 claimedAt;
+        // The stake at the time the claim was made. This is tracked as
+        // rewards can only be claimed after an epoch has ended, but the
+        // user's stake may have changed by then. This field tracks the
+        // staking value before the change so the reward for that epoch
+        // can be manually calculated.
+        uint256 stake;
+    }
+
+    function getRewardPool(
+        uint256 epochId,
+        address stakee
+    ) external view returns (RewardPool memory);
+
+    function getRewardPoolKey(uint256 epochId, address stakee) external pure returns (bytes32);
+
+    function getRewardPoolStakersTotal(
+        uint256 epochId,
+        address stakee
+    ) external view returns (uint256);
+
+    function getRewardPoolActiveStake(
+        uint256 epochId,
+        address stakee
+    ) external view returns (uint256);
+
+    function getPendingRewards(address stakee) external view returns (uint256);
+
+    function getLastClaim(address stakee, address staker) external view returns (LastClaim memory);
+
+    function getTotalEpochRewards(uint256 epochId) external view returns (uint256);
+
+    function getTotalEpochStakingRewards(uint256 epochId) external view returns (uint256);
+
+    function initializeNextRewardPool(address stakee) external;
+
+    function incrementRewardPool(address stakee, uint256 amount) external;
+
+    function claimStakingRewards(address stakee) external returns (uint256);
+
+    function updatePendingRewards(address stakee, address staker) external;
+}

--- a/contracts/interfaces/payments/ticketing/ITicketingParameters.sol
+++ b/contracts/interfaces/payments/ticketing/ITicketingParameters.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.18;
+
+interface ITicketingParameters {
+    function setFaceValue(uint256 _faceValue) external;
+
+    function setBaseLiveWinProb(uint128 _baseLiveWinProb) external;
+
+    function setExpiredWinProb(uint128 _expiredWinProb) external;
+
+    function setDecayRate(uint16 _decayRate) external;
+
+    function setTicketDuration(uint256 _ticketDuration) external;
+
+    function getTicketingParameters()
+        external
+        view
+        returns (uint256, uint128, uint128, uint256, uint16);
+}

--- a/contracts/interfaces/staking/IDirectory.sol
+++ b/contracts/interfaces/staking/IDirectory.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.18;
+
+interface IDirectory {
+    /**
+     * @dev A DirectoryEntry will be stored for every node that joins the
+     * network in a specific epoch. The entry will contain the stakee's
+     * address, and a boundary value which is a sum of the current directory's
+     * total stake, and the current stakee's total stake.
+     */
+    struct DirectoryEntry {
+        address stakee;
+        uint256 boundary;
+    }
+
+    /**
+     * @dev An EpochDirectory will be stored for every epoch. The
+     * directory will be constructed piece by piece as Nodes join,
+     * each adding their own directory entry based on their current
+     * stake value.
+     */
+    struct EpochDirectory {
+        DirectoryEntry[] entries;
+        mapping(address => uint256) stakes;
+        uint256 totalStake;
+    }
+
+    function setCurrentDirectory(uint256 epochId) external;
+
+    function joinNextDirectory(address stakee) external;
+
+    function scan(uint128 point) external view returns (address stakee);
+
+    function scanWithEpochId(
+        uint128 point,
+        uint256 epochId
+    ) external view returns (address stakee);
+
+    function getTotalStakeForStakee(
+        uint256 epochId,
+        address stakee
+    ) external view returns (uint256);
+
+    function getTotalStake(uint256 epochId) external view returns (uint256);
+
+    function getEntries(
+        uint256 epochId
+    ) external view returns (address[] memory, uint256[] memory);
+}

--- a/contracts/interfaces/staking/IStakingManager.sol
+++ b/contracts/interfaces/staking/IStakingManager.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.18;
+
+interface IStakingManager {
+    /**
+     * For every Node, there will be a mapping of the staker to a
+     * StakeEntry. The stake entry tracks the amount of stake in SOLO,
+     * and also when the stake was updated.
+     */
+    struct StakeEntry {
+        uint256 amount;
+        // Block number this entry was updated at
+        uint256 updatedAt;
+        // Epoch this entry was updated. The stake will become active
+        // in the following epoch
+        uint256 epochId;
+    }
+
+    /**
+     * Every Node must have stake in order to participate in the Epoch.
+     * Stake can be provided by the Node itself or by other accounts in
+     * the network.
+     */
+    struct Stake {
+        // Track each stake entry associated to a node
+        mapping(address => StakeEntry) stakeEntries;
+        // The total stake held by this contract for a node,
+        // which will be the sum of all addStake and unlockStake calls
+        uint256 totalManagedStake;
+    }
+
+    /**
+     * This struct will track stake that is in the process of unlocking.
+     */
+    struct Unlock {
+        uint256 amount; // Amount of stake unlocking
+        uint256 unlockAt; // Block number the stake becomes withdrawable
+    }
+
+    function setUnlockDuration(uint256 _unlockDuration) external;
+
+    function setMinimumStakeProportion(uint16 _minimumStakeProportion) external;
+
+    function addStake(uint256 amount, address stakee) external;
+
+    function unlockStake(uint256 amount, address stakee) external returns (uint256);
+
+    function withdrawStake(address stakee) external;
+
+    function cancelUnlocking(uint256 amount, address stakee) external;
+
+    function calculateMaxAdditionalDelegatedStake(address stakee) external view returns (uint256);
+
+    function getTotalManagedStake() external view returns (uint256);
+
+    function getStakeEntry(
+        address stakee,
+        address staker
+    ) external view returns (StakeEntry memory);
+
+    function getStakeeTotalManagedStake(address stakee) external view returns (uint256);
+}

--- a/contracts/libraries/Manageable.sol
+++ b/contracts/libraries/Manageable.sol
@@ -21,12 +21,16 @@ abstract contract Manageable is Ownable2StepUpgradeable {
     mapping(address => uint256) public managers;
 
     error OnlyManagers();
+    error ManagerCannotBeZeroAddress();
 
     /**
      * @notice Adds a manager to this contract. Only callable by the owner.
      * @param manager The address of the manager contract.
      */
     function addManager(address manager) external onlyOwner {
+        if (manager == address(0)) {
+            revert ManagerCannotBeZeroAddress();
+        }
         managers[manager] = block.number;
     }
 

--- a/contracts/libraries/SyloUtils.sol
+++ b/contracts/libraries/SyloUtils.sol
@@ -2,6 +2,12 @@
 pragma solidity ^0.8.18;
 
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+error ContractNameCannotBeEmpty();
+error InterfaceIdCannotBeZeroBytes();
+error TargetContractCannotBeZeroAddress(string name);
+error TargetNotSupportInterface(string name, bytes4 interfaceId);
 
 library SyloUtils {
     /**
@@ -30,5 +36,30 @@ library SyloUtils {
      */
     function asPerc(uint128 numerator, uint256 denominator) internal pure returns (uint16) {
         return SafeCast.toUint16((uint256(numerator) * PERCENTAGE_DENOMINATOR) / denominator);
+    }
+
+    /**
+     * @dev Validate that a contract implements a given interface.
+     * @param name The name of the contract, used in error messages.
+     * @param target The address of the contract.
+     * @param interfaceId The interface ID to check.
+     */
+    function validateContractInterface(
+        string memory name,
+        address target,
+        bytes4 interfaceId
+    ) internal view {
+        if (bytes(name).length == 0) {
+            revert ContractNameCannotBeEmpty();
+        }
+        if (target == address(0)) {
+            revert TargetContractCannotBeZeroAddress(name);
+        }
+        if (interfaceId == bytes4(0)) {
+            revert InterfaceIdCannotBeZeroBytes();
+        }
+        if (!ERC165(target).supportsInterface(interfaceId)) {
+            revert TargetNotSupportInterface(name, interfaceId);
+        }
     }
 }

--- a/contracts/mocks/TestSyloUtils.sol
+++ b/contracts/mocks/TestSyloUtils.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.18;
+
+import "../libraries/SyloUtils.sol";
+
+contract TestSyloUtils {
+    function percOf(uint128 value, uint16 percentage) public pure returns (uint256) {
+        return SyloUtils.percOf(value, percentage);
+    }
+
+    function asPerc(uint128 numerator, uint256 denominator) public pure returns (uint16) {
+        return SyloUtils.asPerc(numerator, denominator);
+    }
+
+    function validateContractInterface(
+        string memory name,
+        address target,
+        bytes4 interfaceId
+    ) public view {
+        SyloUtils.validateContractInterface(name, target, interfaceId);
+    }
+}

--- a/test/epochs.test.ts
+++ b/test/epochs.test.ts
@@ -39,6 +39,24 @@ describe('Epochs', () => {
     ).to.be.revertedWith('Initializable: contract is already initialized');
   });
 
+  it('epoch manager cannot be intialized with invalid arguments', async () => {
+    const EpochsManager = await ethers.getContractFactory('EpochsManager');
+    epochsManager = await EpochsManager.deploy();
+
+    await expect(
+      epochsManager.initialize(
+        ethers.constants.AddressZero,
+        ethers.constants.AddressZero,
+        ethers.constants.AddressZero,
+        ethers.constants.AddressZero,
+        0,
+      ),
+    ).to.be.revertedWithCustomError(
+      epochsManager,
+      'RootSeekerCannotBeZeroAddress',
+    );
+  });
+
   it('can set epoch duration', async () => {
     await expect(epochsManager.setEpochDuration(777))
       .to.emit(epochsManager, 'EpochDurationUpdated')
@@ -50,6 +68,12 @@ describe('Epochs', () => {
       777,
       'Expected epoch duration to be updated',
     );
+  });
+
+  it('can not set epoch duration to zero', async () => {
+    await expect(
+      epochsManager.setEpochDuration(0),
+    ).to.be.revertedWithCustomError(epochsManager, 'EpochDurationCannotBeZero');
   });
 
   it('not owner cannot set epoch duration', async () => {

--- a/test/registries.test.ts
+++ b/test/registries.test.ts
@@ -217,15 +217,6 @@ describe('Registries', () => {
     );
   });
 
-  it('fails to set seeker account when seekerId greater than max seeker id', async () => {
-    const seekerAccount = accounts[1];
-    const seekerAddress = await seekerAccount.getAddress();
-
-    await expect(
-      registries.setSeekerAccount(seekerAddress, 50000, randomBytes(32), '0x'),
-    ).to.be.revertedWithCustomError(registries, 'SeekerIdOutOfRange');
-  });
-
   it('fails to set seeker account when reusing signature', async () => {
     const seekerAccount = accounts[1];
     const seekerAddress = await seekerAccount.getAddress();


### PR DESCRIPTION
Inputs to functions should be validated to prevent any unexpected behaviour. 

Some examples:

- Methods that take in addresses for contracts should be validated that they not address(0). Can also use `supportsInterface`.
- Range validation for certain values (proofDuration for Registries contract)
- Compute ticket hash may be unnecessary as the hash is never validated