### PR TITLE
Net 456 (SLP-13) Safe ownership transfer

### DIFF
--- a/contracts/ECDSA.sol
+++ b/contracts/ECDSA.sol
@@ -84,3 +84,4 @@ library ECDSA {
         return signer;
     }
 }
+

--- a/contracts/Epochs/Manager.sol
+++ b/contracts/Epochs/Manager.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
@@ -14,7 +14,7 @@ error SeekerAcountCannotBeZeroAddress();
 error SeekerOwnerMismatch();
 error SeekerAlreadyJoinedEpoch(uint256 epochId, uint256 seekerId);
 
-contract EpochsManager is Initializable, OwnableUpgradeable {
+contract EpochsManager is Initializable, Ownable2StepUpgradeable {
     /**
      * @dev This struct will hold all network parameters that will be static
      * for the entire epoch. This value will be stored in a mapping, where the
@@ -83,7 +83,7 @@ contract EpochsManager is Initializable, OwnableUpgradeable {
         TicketingParameters ticketingParameters,
         uint256 _epochDuration
     ) external initializer {
-        OwnableUpgradeable.__Ownable_init();
+        Ownable2StepUpgradeable.__Ownable2Step_init();
         _rootSeekers = rootSeekers;
         _directory = directory;
         _registries = registries;

--- a/contracts/Manageable.sol
+++ b/contracts/Manageable.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 
 error OnlyManagers();
 
@@ -13,7 +13,7 @@ error OnlyManagers();
  * `onlyManager`, which can be applied to your functions to restrict their use to
  * other contracts which have explicitly been added.
  */
-abstract contract Manageable is OwnableUpgradeable {
+abstract contract Manageable is Ownable2StepUpgradeable {
     /**
      * @dev Tracks the managers added to this contract, where they key is the
      * address of the managing contract, and the value is the block the manager was added in.

--- a/contracts/Payments/Ticketing.sol
+++ b/contracts/Payments/Ticketing.sol
@@ -10,7 +10,7 @@ import "../Epochs/Manager.sol";
 import "./Ticketing/RewardsManager.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
@@ -36,7 +36,7 @@ error RedeemerCommitMismatch();
  * Micro-Payment Ticketing system that pays Nodes for providing the
  * Event Relay service.
  */
-contract SyloTicketing is Initializable, OwnableUpgradeable {
+contract SyloTicketing is Initializable, Ownable2StepUpgradeable {
     struct Deposit {
         uint256 escrow; // Balance of users escrow
         uint256 penalty; // Balance of users penalty
@@ -105,7 +105,7 @@ contract SyloTicketing is Initializable, OwnableUpgradeable {
         RewardsManager rewardsManager,
         uint256 _unlockDuration
     ) external initializer {
-        OwnableUpgradeable.__Ownable_init();();
+        Ownable2StepUpgradeable.__Ownable2Step_init();
         _token = token;
         _registries = registries;
         _stakingManager = stakingManager;

--- a/contracts/Payments/Ticketing.sol
+++ b/contracts/Payments/Ticketing.sol
@@ -105,7 +105,7 @@ contract SyloTicketing is Initializable, OwnableUpgradeable {
         RewardsManager rewardsManager,
         uint256 _unlockDuration
     ) external initializer {
-        OwnableUpgradeable.__Ownable_init();
+        OwnableUpgradeable.__Ownable_init();();
         _token = token;
         _registries = registries;
         _stakingManager = stakingManager;

--- a/contracts/Payments/Ticketing/Parameters.sol
+++ b/contracts/Payments/Ticketing/Parameters.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "../../Utils.sol";
 
@@ -13,7 +13,7 @@ error TicketDurationCannotBeZero();
  * contract is necessary to avoid a cyclic dependency between the ticketing
  * and epoch contracts.
  */
-contract TicketingParameters is Initializable, OwnableUpgradeable {
+contract TicketingParameters is Initializable, Ownable2StepUpgradeable {
     event FaceValueUpdated(uint256 faceValue);
     event BaseLiveWinProbUpdated(uint128 baseLiveWinprob);
     event ExpiredWinProbUpdated(uint128 expiredWinProb);
@@ -61,7 +61,7 @@ contract TicketingParameters is Initializable, OwnableUpgradeable {
         uint16 _decayRate,
         uint256 _ticketDuration
     ) external initializer {
-        OwnableUpgradeable.__Ownable_init();
+        Ownable2StepUpgradeable.__Ownable2Step_init();
         faceValue = _faceValue;
         baseLiveWinProb = _baseLiveWinProb;
         expiredWinProb = _expiredWinProb;

--- a/contracts/Payments/Ticketing/RewardsManager.sol
+++ b/contracts/Payments/Ticketing/RewardsManager.sol
@@ -126,7 +126,7 @@ contract RewardsManager is Initializable, Manageable {
         StakingManager stakingManager,
         EpochsManager epochsManager
     ) external initializer {
-        OwnableUpgradeable.__Ownable_init();
+        Ownable2StepUpgradeable.__Ownable2Step_init();
         _token = token;
         _epochsManager = epochsManager;
         _stakingManager = stakingManager;

--- a/contracts/Registries.sol
+++ b/contracts/Registries.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.13;
 
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
@@ -23,7 +23,7 @@ error EndCannotExceedNumberOfNodes(uint256 nodeLength);
  * set of parameters configured by the Node itself. A Node is required
  * to have a valid Registry to be able to participate in the network.
  */
-contract Registries is Initializable, OwnableUpgradeable {
+contract Registries is Initializable, Ownable2StepUpgradeable {
     using ECDSA for bytes32;
 
     struct Registry {
@@ -85,7 +85,7 @@ contract Registries is Initializable, OwnableUpgradeable {
         IERC721 rootSeekers,
         uint16 _defaultPayoutPercentage
     ) external initializer {
-        OwnableUpgradeable.__Ownable_init();
+        Ownable2StepUpgradeable.__Ownable2Step_init();
 
         if (_defaultPayoutPercentage > 10000) {
             revert PercentageCannotExceed10000();

--- a/contracts/Staking/Directory.sol
+++ b/contracts/Staking/Directory.sol
@@ -6,7 +6,6 @@ import "../Payments/Ticketing/RewardsManager.sol";
 import "../Utils.sol";
 import "../Manageable.sol";
 
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
@@ -58,7 +57,7 @@ contract Directory is Initializable, Manageable {
         StakingManager stakingManager,
         RewardsManager rewardsManager
     ) external initializer {
-        OwnableUpgradeable.__Ownable_init();
+        Ownable2StepUpgradeable.__Ownable2Step_init();
         _stakingManager = stakingManager;
         _rewardsManager = rewardsManager;
     }

--- a/contracts/Staking/Manager.sol
+++ b/contracts/Staking/Manager.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "../Token.sol";
@@ -24,7 +24,7 @@ error StakeCapacityReached(uint256 maxCapacity, uint256 currentCapacity);
  * Sylo Network. The stake is used in stake-weighted scan function,
  * and delegated stakers are rewarded on a pro-rata basis.
  */
-contract StakingManager is Initializable, OwnableUpgradeable {
+contract StakingManager is Initializable, Ownable2StepUpgradeable {
     /** ERC 20 compatible token we are dealing with */
     IERC20 public _token;
 
@@ -110,7 +110,7 @@ contract StakingManager is Initializable, OwnableUpgradeable {
         uint256 _unlockDuration,
         uint16 _minimumStakeProportion
     ) external initializer {
-        OwnableUpgradeable.__Ownable_init();
+        Ownable2StepUpgradeable.__Ownable2Step_init();
         _token = token;
         _rewardsManager = rewardsManager;
         _epochsManager = epochsManager;


### PR DESCRIPTION
## Motivation

We use the `Ownable` lib to allow the Sylo to administrate the network protocol. This is an industry standard but imposes some risk in the case we accidentally transfer to an account that is invalid or does not exist. This PR replaces the Ownable contract with `Ownable2Step`, which forces the transferee of the ownership to explicitly send a claim for the ownership in order for the ownership to transer.

The `Ownable2Step` interface https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable/blob/master/contracts/access/Ownable2StepUpgradeable.sol

## Summary of Changes

- Replace `Ownable` with `Ownable2Step`