### PR TITLE
NET-444 Optimise event ticket validation in notify events

### DIFF
--- a/contracts/interfaces/payments/ISyloTicketing.sol
+++ b/contracts/interfaces/payments/ISyloTicketing.sol
@@ -5,7 +5,6 @@ interface ISyloTicketing {
     struct Deposit {
         uint256 escrow; // Balance of users escrow
         uint256 penalty; // Balance of users penalty
-        uint256 callUnlockAt; // Block number a user call unlock process
         uint256 unlockAt; // Block number a user can withdraw their balances
     }
 

--- a/contracts/interfaces/payments/ISyloTicketing.sol
+++ b/contracts/interfaces/payments/ISyloTicketing.sol
@@ -5,6 +5,7 @@ interface ISyloTicketing {
     struct Deposit {
         uint256 escrow; // Balance of users escrow
         uint256 penalty; // Balance of users penalty
+        uint256 callUnlockAt; // Block number a user call unlock process
         uint256 unlockAt; // Block number a user can withdraw their balances
     }
 

--- a/contracts/payments/SyloTicketing.sol
+++ b/contracts/payments/SyloTicketing.sol
@@ -231,11 +231,10 @@ contract SyloTicketing is ISyloTicketing, Initializable, Ownable2StepUpgradeable
         if (deposit.escrow == 0 && deposit.penalty == 0) {
             revert NoEsrowAndPenalty();
         }
-        if (deposit.unlockAt != 0 || deposit.callUnlockAt != 0) {
+        if (deposit.unlockAt != 0) {
             revert UnlockingInProcess();
         }
 
-        deposit.callUnlockAt = block.number;
         deposit.unlockAt = block.number + unlockDuration;
 
         return deposit.unlockAt;
@@ -247,11 +246,10 @@ contract SyloTicketing is ISyloTicketing, Initializable, Ownable2StepUpgradeable
      */
     function lockDeposits() external {
         Deposit storage deposit = getDeposit(msg.sender);
-        if (deposit.unlockAt == 0 || deposit.callUnlockAt == 0) {
+        if (deposit.unlockAt == 0) {
             revert UnlockingNotInProcess();
         }
 
-        delete deposit.callUnlockAt;
         delete deposit.unlockAt;
     }
 
@@ -272,7 +270,7 @@ contract SyloTicketing is ISyloTicketing, Initializable, Ownable2StepUpgradeable
      */
     function withdrawTo(address account) public {
         Deposit memory deposit = getDeposit(msg.sender);
-        if (deposit.unlockAt == 0 || deposit.callUnlockAt == 0) {
+        if (deposit.unlockAt == 0) {
             revert UnlockingNotInProcess();
         }
         if (deposit.unlockAt >= block.number) {

--- a/test/payments/ticketing.test.ts
+++ b/test/payments/ticketing.test.ts
@@ -430,6 +430,11 @@ describe('Ticketing', () => {
       0,
       'Expected deposit to go into unlocking phase',
     );
+    assert.isAbove(
+        deposit.callUnlockAt.toNumber(),
+        0,
+        'Expected deposit to go into unlocking phase',
+    );
   });
 
   it('should fail to unlock if already unlocking', async () => {
@@ -461,6 +466,11 @@ describe('Ticketing', () => {
       deposit.unlockAt.toString(),
       '0',
       'Expected deposit to move out of unlocking phase',
+    );
+    assert.equal(
+        deposit.callUnlockAt.toString(),
+        '0',
+        'Expected deposit to move out of unlocking phase',
     );
   });
 
@@ -905,7 +915,9 @@ describe('Ticketing', () => {
 
     const initialTicketingBalance = await token.balanceOf(ticketing.address);
 
-    await ticketing.redeem(ticket, senderRand, redeemerRand, signature);
+    await expect(ticketing.redeem(ticket, senderRand, redeemerRand, signature))
+        .to.emit(ticketing, 'SenderPenaltyBurnt')
+        .withArgs(alice.address)
 
     const deposit = await ticketing.deposits(alice.address);
     assert.equal(

--- a/test/payments/ticketing.test.ts
+++ b/test/payments/ticketing.test.ts
@@ -430,11 +430,6 @@ describe('Ticketing', () => {
       0,
       'Expected deposit to go into unlocking phase',
     );
-    assert.isAbove(
-        deposit.callUnlockAt.toNumber(),
-        0,
-        'Expected deposit to go into unlocking phase',
-    );
   });
 
   it('should fail to unlock if already unlocking', async () => {
@@ -466,11 +461,6 @@ describe('Ticketing', () => {
       deposit.unlockAt.toString(),
       '0',
       'Expected deposit to move out of unlocking phase',
-    );
-    assert.equal(
-        deposit.callUnlockAt.toString(),
-        '0',
-        'Expected deposit to move out of unlocking phase',
     );
   });
 


### PR DESCRIPTION
## Motivation

In phase 3, the node will check the senders' deposits when they request relays to the node. Instead of making a call to the blockchain for each relay request that is highly expensive in terms of API call rate, the nodes will store senders' deposits in their own caches, and just need to query on chain after an unlock duration to update data.

However, we have to make sure that the information of senders' deposit in cache must be up-to-date, so that the node can eliminate from being exploited by some bad senders. 

There are an issue that might negatively affect the node

**Problem ** 
The senders' deposits might be burned by other nodes after this node saves the valid senders' deposits in its cache. Because this node depends on its cache, (just query again after the unlock_duration time), this node may not know that these senders' deposit are invalid on chain right now. Therefore, when this node accept relays from these senders, it cannot redeem the winning ticket. 
**Solution**
We can add SenderPenaltyBurnt event when senders' penalty are burned. All nodes can subscribe to this event. When this happens, all the node can know and filter the bad senders in their own cache.

## Summary of changes

- add event when sender's penalty is burned
