### PR TITLE
NET-477 Delete duplicated seeker account after another node sets seeker account

### DIFF
--- a/contracts/Registries.sol
+++ b/contracts/Registries.sol
@@ -161,6 +161,7 @@ contract Registries is IRegistries, Initializable, Ownable2StepUpgradeable, IERC
         }
 
         delete registries[seekerRegistration[seekerId]].seekerId;
+        delete registries[seekerRegistration[seekerId]].seekerAccount;
 
         registries[msg.sender].seekerAccount = seekerAccount;
         registries[msg.sender].seekerId = seekerId;

--- a/test/registries.test.ts
+++ b/test/registries.test.ts
@@ -367,9 +367,15 @@ describe('Registries', () => {
       accountAddressTwo,
     );
 
-    // tests that the registry for both seeker accounts don't have the same seekerID
     expect(regoSeekerAccountOne.seekerId).to.equal(0);
+    expect(regoSeekerAccountOne.seekerAccount).to.equal(
+      ethers.constants.AddressZero,
+    );
+
     expect(regoSeekerAccountTwo.seekerId).is.equal(tokenID);
+    expect(regoSeekerAccountTwo.seekerAccount).is.equal(
+      await seekerAccount.getAddress(),
+    );
   });
 
   it('has the correct prefix message', async () => {


### PR DESCRIPTION
A valid seeker registration should compose of both a non zero seeker id and a non zero seeker account field in the registry. We currently overwrite the seeker id field to zero for the existing registration when using the same seeker id. We should do the same for the seeker field as well.