### PR TITLE
NET-484 Fix used tickets reentrancy problem

### DIFF
--- a/contracts/payments/SyloTicketing.sol
+++ b/contracts/payments/SyloTicketing.sol
@@ -311,6 +311,8 @@ contract SyloTicketing is ISyloTicketing, Initializable, Ownable2StepUpgradeable
 
         bytes32 ticketHash = requireValidWinningTicket(ticket, senderRand, redeemerRand, sig);
 
+        usedTickets[ticketHash] = true;
+
         uint256 directoryStake = _directory.getTotalStakeForStakee(
             ticket.epochId,
             ticket.redeemer
@@ -318,8 +320,6 @@ contract SyloTicketing is ISyloTicketing, Initializable, Ownable2StepUpgradeable
         if (directoryStake == 0) {
             revert RedeemerMustHaveJoinedEpoch(ticket.epochId);
         }
-
-        usedTickets[ticketHash] = true;
 
         uint256 rewardAmount = rewardRedeemer(epoch, ticket);
 


### PR DESCRIPTION
The second audit review noted that the movement of `usedTickets[ticketHash] = true` presented a vulnerability as it ended up being placed after an external call.

This PR reverts that change.