### PR TITLE
NET-550 Add-delegated-account

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,9 @@ jobs:
       - run:
           name: test contracts
           command: yarn coverage
+      - run:
+          name: check coverage
+          command: npx istanbul check-coverage --statements 100 --functions 100 --lines 100
       - store_artifacts:
           path: ~/sylo-ethereum-contracts/coverage
 

--- a/contracts/AuthorizedAccount.sol
+++ b/contracts/AuthorizedAccount.sol
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.18;
+
+import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+
+import "./interfaces/IAuthorizedAccount.sol";
+
+/**
+ * @notice Manages authorized accounts with limited permissions on behalf of main account
+ * these authorized accounts are allowed to perform some certain actions in the Sylo network
+ * in order to reduce the works for main account
+ */
+contract AuthorizedAccount is IAuthorizedAccount, Initializable, Ownable2StepUpgradeable, ERC165 {
+    /**
+     * @notice Tracks authorized accounts for every main account
+     */
+    mapping(address => AuthorizedAccount[]) public authorizedAccounts;
+
+    error AuthorizedAccountCannotBeZeroAddress();
+    error MainAccountCannotBeZeroAddress();
+    error AccountAlreadyExists();
+    error AccountDoesNotExist();
+
+    function initialize() external initializer {
+        Ownable2StepUpgradeable.__Ownable2Step_init();
+    }
+
+    /**
+     * @notice Returns true if the contract implements the interface defined by
+     * `interfaceId` from ERC165.
+     */
+    function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+        return interfaceId == type(IAuthorizedAccount).interfaceId;
+    }
+
+    /**
+     * @notice Adds new authorized accounts with certain permissions. This will revert if the account
+     * has already existed
+     * @param authorized The authorized address of the main account
+     * @param permissions The list of permissions that the authorized account
+     * can perform within the Sylo network.
+     */
+    function authorizeAccount(address authorized, Permission[] calldata permissions) external {
+        if (authorized == address(0)) {
+            revert AuthorizedAccountCannotBeZeroAddress();
+        }
+
+        // check if account has already existed
+        AuthorizedAccount[] storage _authorizedAccounts = authorizedAccounts[msg.sender];
+        for (uint i = 0; i < _authorizedAccounts.length; i++) {
+            if (_authorizedAccounts[i].account == authorized) {
+                revert AccountAlreadyExists();
+            }
+        }
+
+        AuthorizedAccount memory newAccount = AuthorizedAccount({
+            account: authorized,
+            createdAt: block.number,
+            permissions: permissions
+        });
+
+        authorizedAccounts[msg.sender].push(newAccount);
+    }
+
+    /**
+     * @notice Removes an authorized account associated with the msg.sender.
+     * This will revert if the account does not exist
+     * @param authorized The address of the authorized account
+     */
+    function unauthorizeAccount(address authorized) external {
+        if (authorized == address(0)) {
+            revert AuthorizedAccountCannotBeZeroAddress();
+        }
+
+        AuthorizedAccount[] storage _authorizedAccounts = authorizedAccounts[msg.sender];
+        for (uint i = 0; i < _authorizedAccounts.length; i++) {
+            if (_authorizedAccounts[i].account == authorized) {
+                _authorizedAccounts[i] = _authorizedAccounts[_authorizedAccounts.length - 1];
+                _authorizedAccounts.pop();
+                return;
+            }
+        }
+
+        revert AccountDoesNotExist();
+    }
+
+    /**
+     * @notice Adds new permissions to a specific authorized account. This will revert if
+     * the account does not exist. Adding existing permissions will have no effect
+     * @param authorized The address of authorized account
+     * @param permissions The new permissions will be added for the authorized account
+     */
+    function addPermissions(address authorized, Permission[] calldata permissions) external {
+        if (authorized == address(0)) {
+            revert AuthorizedAccountCannotBeZeroAddress();
+        }
+
+        AuthorizedAccount[] storage _authorizedAccounts = authorizedAccounts[msg.sender];
+        for (uint i = 0; i < _authorizedAccounts.length; i++) {
+            if (_authorizedAccounts[i].account == authorized) {
+                // iterate over the permissions
+                for (uint j = 0; j < permissions.length; j++) {
+                    // check if the permission already exists in the permissions array.
+                    bool exists = false;
+                    for (uint k = 0; k < _authorizedAccounts[i].permissions.length; k++) {
+                        if (_authorizedAccounts[i].permissions[k] == permissions[j]) {
+                            exists = true;
+                            break;
+                        }
+                    }
+                    // if the permission does not already exist, add it
+                    // otherwise, just skip duplicated permission
+                    if (!exists) {
+                        _authorizedAccounts[i].permissions.push(permissions[j]);
+                    }
+                }
+                return;
+            }
+        }
+        revert AccountDoesNotExist();
+    }
+
+    /**
+     * @notice Removes permissions of specific authorized account. This will revert if the account
+     * does not exist.
+     * @param authorized The address of authorized account
+     * @param permissions The list of permissions will be removed
+     */
+    function removePermissions(address authorized, Permission[] calldata permissions) external {
+        if (authorized == address(0)) {
+            revert AuthorizedAccountCannotBeZeroAddress();
+        }
+
+        AuthorizedAccount[] storage _authorizedAccounts = authorizedAccounts[msg.sender];
+        for (uint i = 0; i < _authorizedAccounts.length; i++) {
+            if (_authorizedAccounts[i].account == authorized) {
+                // create temporary array to store the permissions to keep
+                Permission[] memory newPermissions = new Permission[](
+                    _authorizedAccounts[i].permissions.length
+                );
+
+                uint counter = 0;
+                // iterate over the existing permissions
+                for (uint j = 0; j < _authorizedAccounts[i].permissions.length; j++) {
+                    bool shouldRemove = false;
+                    for (uint k = 0; k < permissions.length; k++) {
+                        if (_authorizedAccounts[i].permissions[j] == permissions[k]) {
+                            shouldRemove = true;
+                            break;
+                        }
+                    }
+                    // if the permission should not be removed, add it to the new permissions array.
+                    if (!shouldRemove) {
+                        newPermissions[counter] = _authorizedAccounts[i].permissions[j];
+                        counter++;
+                    }
+                }
+
+                // replace the old permissions array with the new one.
+                delete _authorizedAccounts[i].permissions;
+                for (uint j = 0; j < counter; j++) {
+                    _authorizedAccounts[i].permissions.push(newPermissions[j]);
+                }
+                return;
+            }
+        }
+
+        revert AccountDoesNotExist();
+    }
+
+    /**
+     * @notice Validates permission of an authorized account associated with the main account.
+     * @param main The address of main account
+     * @param authorized The address of authorized account
+     * @param permission The permission needs to be verified with the authorized account
+     * @return boolean value
+     */
+    function validatePermission(
+        address main,
+        address authorized,
+        Permission permission
+    ) external view returns (bool) {
+        if (main == address(0)) {
+            revert MainAccountCannotBeZeroAddress();
+        }
+
+        if (authorized == address(0)) {
+            revert AuthorizedAccountCannotBeZeroAddress();
+        }
+
+        AuthorizedAccount[] memory _authorizedAccounts = authorizedAccounts[main];
+        for (uint i = 0; i < _authorizedAccounts.length; i++) {
+            if (_authorizedAccounts[i].account == authorized) {
+                for (uint j = 0; j < _authorizedAccounts[i].permissions.length; j++) {
+                    if (_authorizedAccounts[i].permissions[j] == permission) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @notice Get all authorized accounts associated with a given account
+     * @param main The address of main account
+     * @return An array of authorized accounts
+     */
+    function getAuthorizedAccounts(
+        address main
+    ) external view returns (AuthorizedAccount[] memory) {
+        if (main == address(0)) {
+            revert MainAccountCannotBeZeroAddress();
+        }
+
+        return authorizedAccounts[main];
+    }
+}

--- a/contracts/interfaces/IAuthorizedAccount.sol
+++ b/contracts/interfaces/IAuthorizedAccount.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.18;
+
+interface IAuthorizedAccount {
+    enum Permission {
+        DepositWithdrawal
+    }
+
+    struct AuthorizedAccount {
+        address account; // Address of the authorized account
+        uint256 createdAt; // Block number the authorized account was created
+        Permission[] permissions; // Permissions associated with delegated account
+    }
+
+    function authorizeAccount(address authorized, Permission[] calldata permissions) external;
+
+    function unauthorizeAccount(address authorized) external;
+
+    function addPermissions(address authorized, Permission[] calldata permissions) external;
+
+    function removePermissions(
+        address authorized,
+        Permission[] calldata permissionsToRemove
+    ) external;
+
+    function validatePermission(
+        address main,
+        address authorized,
+        Permission permission
+    ) external returns (bool);
+
+    function getAuthorizedAccounts(
+        address main
+    ) external view returns (AuthorizedAccount[] memory);
+}

--- a/contracts/interfaces/payments/ISyloTicketing.sol
+++ b/contracts/interfaces/payments/ISyloTicketing.sol
@@ -11,6 +11,7 @@ interface ISyloTicketing {
     struct Ticket {
         uint256 epochId; // The epoch this ticket is associated with
         address sender; // Address of the ticket sender
+        address delegatedSender; // Address of the ticket's signer if not the original sender (optional)
         address redeemer; // Address of the intended recipient
         uint256 generationBlock; // Block number the ticket was generated
         bytes32 senderCommit; // Hash of the secret random number of the sender

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "npx hardhat compile",
     "test": "npx hardhat test",
     "coverage": "npx hardhat coverage",
+    "check-coverage": "node check-coverage.js",
     "solhint": "solhint 'contracts/**/*.sol'",
     "package-abi": "npx ts-node scripts/parse_artifacts.ts && npx ts-node scripts/package_abis.ts",
     "docker-rootnet": "DOCKER_BUILDKIT=1 docker buildx build --platform linux/amd64 . -f docker/rootnet-with-protocol/Dockerfile -t dn3010/sylo-ethereum-testnet:rootnet",

--- a/test/authorizedAccount.test.ts
+++ b/test/authorizedAccount.test.ts
@@ -1,0 +1,401 @@
+import { ethers } from 'hardhat';
+import { Signer } from 'ethers';
+import { AuthorizedAccount, SyloToken } from '../typechain-types';
+import utils, { Contracts } from './utils';
+import { assert, expect } from 'chai';
+
+describe('Authorized Account', () => {
+  let accounts: Signer[];
+  let deployer: string;
+  let mainAccount: Signer;
+  let mainAccountAddress: string;
+  let delegatedAccount1: string;
+  let delegatedAccount2: string;
+  let delegatedAccount3: string;
+
+  let token: SyloToken;
+  let authorizedAccount: AuthorizedAccount;
+  let contracts: Contracts;
+
+  enum Permission {
+    DepositWithdrawal,
+  }
+
+  before(async () => {
+    accounts = await ethers.getSigners();
+    deployer = await accounts[0].getAddress();
+    mainAccount = accounts[1];
+    mainAccountAddress = await mainAccount.getAddress();
+    delegatedAccount1 = await accounts[2].getAddress();
+    delegatedAccount2 = await accounts[3].getAddress();
+    delegatedAccount3 = await accounts[4].getAddress();
+
+    const Token = await ethers.getContractFactory('SyloToken');
+    token = await Token.deploy();
+  });
+
+  beforeEach(async () => {
+    contracts = await utils.initializeContracts(deployer, token.address);
+    authorizedAccount = contracts.authorizedAccount;
+  });
+
+  it('authorized account cannot be initialized again', async () => {
+    await expect(authorizedAccount.initialize()).to.be.revertedWith(
+      'Initializable: contract is already initialized',
+    );
+  });
+
+  it('cannot add zero authorized account', async () => {
+    const permission: Permission[] = [Permission.DepositWithdrawal];
+    await expect(
+      authorizedAccount
+        .connect(mainAccount)
+        .authorizeAccount(ethers.constants.AddressZero, permission),
+    ).to.be.revertedWithCustomError(
+      authorizedAccount,
+      'AuthorizedAccountCannotBeZeroAddress',
+    );
+  });
+
+  it('can add unexisted authorized account', async () => {
+    const permission: Permission[] = [Permission.DepositWithdrawal];
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount1, permission);
+    const authorizedAccounts = await authorizedAccount
+      .connect(mainAccount)
+      .getAuthorizedAccounts(mainAccountAddress);
+    assert.equal(authorizedAccounts[0].account, delegatedAccount1);
+    assert.equal(authorizedAccounts.length, 1);
+  });
+
+  it('can add multiple unexisted authorized account', async () => {
+    const permission: Permission[] = [Permission.DepositWithdrawal];
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount1, permission);
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount2, permission);
+    const authorizedAccounts = await authorizedAccount
+      .connect(mainAccount)
+      .getAuthorizedAccounts(mainAccountAddress);
+    assert.equal(authorizedAccounts[0].account, delegatedAccount1);
+    assert.equal(authorizedAccounts[1].account, delegatedAccount2);
+    assert.equal(authorizedAccounts.length, 2);
+  });
+
+  it('cannot add existed authorized account', async () => {
+    const permission: Permission[] = [Permission.DepositWithdrawal];
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount1, permission);
+    await expect(
+      authorizedAccount
+        .connect(mainAccount)
+        .authorizeAccount(delegatedAccount1, permission),
+    ).to.be.revertedWithCustomError(authorizedAccount, 'AccountAlreadyExists');
+  });
+
+  it('cannot unauthorize invalid authorized account', async () => {
+    await expect(
+      authorizedAccount
+        .connect(mainAccount)
+        .unauthorizeAccount(ethers.constants.AddressZero),
+    ).to.be.revertedWithCustomError(
+      authorizedAccount,
+      'AuthorizedAccountCannotBeZeroAddress',
+    );
+  });
+
+  it('cannot unauthorize account if none account is available', async () => {
+    await expect(
+      authorizedAccount
+        .connect(mainAccount)
+        .unauthorizeAccount(delegatedAccount1),
+    ).to.be.revertedWithCustomError(authorizedAccount, 'AccountDoesNotExist');
+  });
+
+  it('cannot unauthorize unexisted account', async () => {
+    const permission: Permission[] = [Permission.DepositWithdrawal];
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount1, permission);
+    await expect(
+      authorizedAccount
+        .connect(mainAccount)
+        .unauthorizeAccount(delegatedAccount2),
+    ).to.be.revertedWithCustomError(authorizedAccount, 'AccountDoesNotExist');
+  });
+
+  it('can unauthorize existed account', async () => {
+    const permission: Permission[] = [Permission.DepositWithdrawal];
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount1, permission);
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount2, permission);
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount3, permission);
+    let authorizedAccounts = await authorizedAccount
+      .connect(mainAccount)
+      .getAuthorizedAccounts(mainAccountAddress);
+    assert.equal(authorizedAccounts[0].account, delegatedAccount1);
+    assert.equal(authorizedAccounts[1].account, delegatedAccount2);
+    assert.equal(authorizedAccounts[2].account, delegatedAccount3);
+    assert.equal(authorizedAccounts.length, 3);
+
+    await authorizedAccount
+      .connect(mainAccount)
+      .unauthorizeAccount(delegatedAccount2);
+    authorizedAccounts = await authorizedAccount
+      .connect(mainAccount)
+      .getAuthorizedAccounts(mainAccountAddress);
+    assert.equal(authorizedAccounts[0].account, delegatedAccount1);
+    assert.equal(authorizedAccounts[1].account, delegatedAccount3);
+    assert.equal(authorizedAccounts.length, 2);
+  });
+
+  it('cannot add permission for invalid delegated account', async () => {
+    const permission: Permission[] = [Permission.DepositWithdrawal];
+    await expect(
+      authorizedAccount
+        .connect(mainAccount)
+        .addPermissions(ethers.constants.AddressZero, permission),
+    ).to.be.revertedWithCustomError(
+      authorizedAccount,
+      'AuthorizedAccountCannotBeZeroAddress',
+    );
+  });
+
+  it('cannot add permission for unexisted delegated account', async () => {
+    const permission: Permission[] = [Permission.DepositWithdrawal];
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount2, permission);
+    await expect(
+      authorizedAccount
+        .connect(mainAccount)
+        .addPermissions(delegatedAccount1, permission),
+    ).to.be.revertedWithCustomError(authorizedAccount, 'AccountDoesNotExist');
+  });
+
+  it('can add permission for existed delegated account', async () => {
+    const permission: Permission[] = [];
+    const newPermission: Permission[] = [Permission.DepositWithdrawal];
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount1, permission);
+    await authorizedAccount
+      .connect(mainAccount)
+      .addPermissions(delegatedAccount1, newPermission);
+    await authorizedAccount
+      .connect(mainAccount)
+      .addPermissions(delegatedAccount1, newPermission);
+    const accounts = await authorizedAccount
+      .connect(mainAccount)
+      .getAuthorizedAccounts(mainAccountAddress);
+    assert.equal(accounts[0].permissions.length, 1);
+  });
+
+  it('can add multiple permissions (with duplicated permissions) for existed delegated account', async () => {
+    const permission: Permission[] = [];
+    const newPermissions: Permission[] = [
+      Permission.DepositWithdrawal,
+      Permission.DepositWithdrawal,
+    ];
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount1, permission);
+    await authorizedAccount
+      .connect(mainAccount)
+      .addPermissions(delegatedAccount1, newPermissions);
+    const accounts = await authorizedAccount
+      .connect(mainAccount)
+      .getAuthorizedAccounts(mainAccountAddress);
+    assert.equal(accounts[0].permissions.length, 1);
+  });
+
+  it('can add existed permission for current delegated account but permissions will not be duplicated', async () => {
+    const permission: Permission[] = [Permission.DepositWithdrawal];
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount1, permission);
+    await authorizedAccount
+      .connect(mainAccount)
+      .addPermissions(delegatedAccount1, permission);
+    const accounts = await authorizedAccount
+      .connect(mainAccount)
+      .getAuthorizedAccounts(mainAccountAddress);
+    assert.equal(accounts[0].permissions.length, 1);
+  });
+
+  it('can remove multiple permissions (with duplicated permissions) for existed delegated account', async () => {
+    const permissionsToAdd: Permission[] = [Permission.DepositWithdrawal];
+    const permissionsToRemove: Permission[] = [
+      Permission.DepositWithdrawal,
+      Permission.DepositWithdrawal,
+    ];
+    const emptyPermissions: Permission[] = [];
+    const permission2: Permission[] = [Permission.DepositWithdrawal];
+
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount1, permissionsToAdd);
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount2, permission2);
+
+    let accounts = await authorizedAccount
+      .connect(mainAccount)
+      .getAuthorizedAccounts(mainAccountAddress);
+    assert.equal(accounts[0].permissions.length, 1);
+
+    await authorizedAccount
+      .connect(mainAccount)
+      .removePermissions(delegatedAccount1, emptyPermissions);
+
+    accounts = await authorizedAccount
+      .connect(mainAccount)
+      .getAuthorizedAccounts(mainAccountAddress);
+    assert.equal(accounts[0].permissions.length, 1);
+
+    await authorizedAccount
+      .connect(mainAccount)
+      .removePermissions(delegatedAccount1, permissionsToRemove);
+
+    accounts = await authorizedAccount
+      .connect(mainAccount)
+      .getAuthorizedAccounts(mainAccountAddress);
+    assert.equal(accounts[0].permissions.length, 0);
+  });
+
+  it('cannot remove permission for unexisted delegated account', async () => {
+    const permission: Permission[] = [Permission.DepositWithdrawal];
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount2, permission);
+    await expect(
+      authorizedAccount
+        .connect(mainAccount)
+        .removePermissions(delegatedAccount1, permission),
+    ).to.be.revertedWithCustomError(authorizedAccount, 'AccountDoesNotExist');
+  });
+
+  it('cannot remove permission with zero authorized account', async () => {
+    const permission: Permission[] = [Permission.DepositWithdrawal];
+    const authorizedAddress = ethers.constants.AddressZero;
+    await expect(
+      authorizedAccount
+        .connect(mainAccount)
+        .removePermissions(authorizedAddress, permission),
+    ).to.be.revertedWithCustomError(
+      authorizedAccount,
+      'AuthorizedAccountCannotBeZeroAddress',
+    );
+  });
+
+  it('can remove permission', async () => {
+    const permission: Permission[] = [Permission.DepositWithdrawal];
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount1, permission);
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount2, permission);
+    let accounts = await authorizedAccount
+      .connect(mainAccount)
+      .getAuthorizedAccounts(mainAccountAddress);
+    assert.equal(accounts[0].permissions.length, 1);
+    await authorizedAccount
+      .connect(mainAccount)
+      .removePermissions(delegatedAccount1, permission);
+    accounts = await authorizedAccount
+      .connect(mainAccount)
+      .getAuthorizedAccounts(mainAccountAddress);
+    assert.equal(accounts[0].permissions.length, 0);
+  });
+
+  it('cannot get authorized accounts associated with invalid main account', async () => {
+    const main = ethers.constants.AddressZero;
+    await expect(
+      authorizedAccount.connect(mainAccount).getAuthorizedAccounts(main),
+    ).to.be.revertedWithCustomError(
+      authorizedAccount,
+      'MainAccountCannotBeZeroAddress',
+    );
+  });
+
+  it('cannot validate permission with invalid main address ', async () => {
+    const main = ethers.constants.AddressZero;
+    const permission = Permission.DepositWithdrawal;
+    await expect(
+      authorizedAccount
+        .connect(mainAccount)
+        .validatePermission(main, delegatedAccount1, permission),
+    ).to.be.revertedWithCustomError(
+      authorizedAccount,
+      'MainAccountCannotBeZeroAddress',
+    );
+  });
+
+  it('cannot validate permission with invalid authorized address ', async () => {
+    const authorizedAddress = ethers.constants.AddressZero;
+    const permission = Permission.DepositWithdrawal;
+    await expect(
+      authorizedAccount
+        .connect(mainAccount)
+        .validatePermission(mainAccountAddress, authorizedAddress, permission),
+    ).to.be.revertedWithCustomError(
+      authorizedAccount,
+      'AuthorizedAccountCannotBeZeroAddress',
+    );
+  });
+
+  it('return false when validating permission with unavailable authorized account ', async () => {
+    const permission: Permission[] = [Permission.DepositWithdrawal];
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount1, permission);
+    const validate = await authorizedAccount
+      .connect(mainAccount)
+      .validatePermission(
+        mainAccountAddress,
+        delegatedAccount2,
+        Permission.DepositWithdrawal,
+      );
+    assert.equal(validate, false);
+  });
+
+  it('return false if authorized account does not have valid permission', async () => {
+    const permission: Permission[] = [];
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount1, permission);
+    const validate = await authorizedAccount
+      .connect(mainAccount)
+      .validatePermission(
+        mainAccountAddress,
+        delegatedAccount1,
+        Permission.DepositWithdrawal,
+      );
+    assert.equal(validate, false);
+  });
+
+  it('return true if authorized account has valid permission', async () => {
+    const permission: Permission[] = [Permission.DepositWithdrawal];
+    await authorizedAccount
+      .connect(mainAccount)
+      .authorizeAccount(delegatedAccount1, permission);
+    const validate = await authorizedAccount
+      .connect(mainAccount)
+      .validatePermission(
+        mainAccountAddress,
+        delegatedAccount1,
+        Permission.DepositWithdrawal,
+      );
+    assert.equal(validate, true);
+  });
+});

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -10,6 +10,7 @@ import {
   SyloTicketing,
   TicketingParameters,
   TestSeekers,
+  AuthorizedAccount,
 } from '../typechain-types';
 import { randomBytes } from 'crypto';
 
@@ -34,6 +35,7 @@ export type Contracts = {
   epochsManager: EpochsManager;
   stakingManager: StakingManager;
   seekers: TestSeekers;
+  authorizedAccount: AuthorizedAccount;
 };
 
 const initializeContracts = async function (
@@ -94,6 +96,11 @@ const initializeContracts = async function (
   const DirectoryFactory = await ethers.getContractFactory('Directory');
   const directory = await DirectoryFactory.deploy();
 
+  const AuthorizedAccountFactory = await ethers.getContractFactory(
+    'AuthorizedAccount',
+  );
+  const authorizedAccount = await AuthorizedAccountFactory.deploy();
+
   await stakingManager.initialize(
     tokenAddress,
     rewardsManager.address,
@@ -119,6 +126,7 @@ const initializeContracts = async function (
     epochDuration,
     { from: deployer },
   );
+  await authorizedAccount.initialize({ from: deployer });
 
   const TicketingFactory = await ethers.getContractFactory('SyloTicketing');
   const ticketing = await TicketingFactory.deploy();
@@ -129,6 +137,7 @@ const initializeContracts = async function (
     directory.address,
     epochsManager.address,
     rewardsManager.address,
+    authorizedAccount.address,
     unlockDuration,
     { from: deployer },
   );
@@ -148,6 +157,7 @@ const initializeContracts = async function (
     epochsManager,
     stakingManager,
     seekers,
+    authorizedAccount,
   };
 };
 


### PR DESCRIPTION
## Motivation
As outlined in this here https://www.notion.so/futureverse/RFC-Alleviating-user-friction-in-ticket-creation-process-1b1416776aee4532b513c638ae976e23#1616abd90910416da6fc434fe41e5e0a, we can modify the signature verification check for tickets to rely on a signature from a different wallet, one that has been delegated by the holder of the deposit.

This solution involves:
- Implement new contract to store authorised accounts
- Add additional field in current ticket structure to indicate if the signature is from the main account or a delegated account
- Check permission of the delegated account before withdrawing sender deposit
- Verify signature if delegated account is used in the ticket

## Summary of changes 
- implement authorized account contract
- integrate authorized account contract with ticketing contract
- adding necessary tests