### PR TITLE
NET-617 Only update unauthorizedAt if the permission is authorized

### DIFF
--- a/contracts/AuthorizedAccounts.sol
+++ b/contracts/AuthorizedAccounts.sol
@@ -205,7 +205,13 @@ contract AuthorizedAccounts is
         for (uint i; i < permissions.length; ++i) {
             for (uint j; j < authAccount.permissions.length; ++j) {
                 if (permissions[i] == authAccount.permissions[j].permission) {
-                    authAccount.permissions[j].unauthorizedAt = block.number + 1;
+                    // only update unauthorizedAt if the permission is authorized
+                    if (
+                        authAccount.permissions[j].authorizedAt >=
+                        authAccount.permissions[j].unauthorizedAt
+                    ) {
+                        authAccount.permissions[j].unauthorizedAt = block.number + 1;
+                    }
                     break;
                 }
             }

--- a/test/authorizedAccount.test.ts
+++ b/test/authorizedAccount.test.ts
@@ -518,6 +518,8 @@ describe('Authorized Accounts', () => {
       mainAccountAddress,
     );
 
+    const expectedUnauthorizedAt = (await currentBlock()) + 1n;
+
     assert.equal(accounts[0].permissions.length, 1);
     assert.equal(
       accounts[0].permissions[0].permission,
@@ -526,7 +528,28 @@ describe('Authorized Accounts', () => {
     assert.equal(accounts[0].permissions[0].authorizedAt, authorizedAtBlock);
     assert.equal(
       accounts[0].permissions[0].unauthorizedAt,
-      (await currentBlock()) + 1n,
+      expectedUnauthorizedAt,
+    );
+
+    // can remove again without any effect
+    await authAccountsConnectMain.removePermissions(
+      delegatedAccount1,
+      permissionList,
+    );
+
+    accounts = await authAccountsConnectMain.getAuthorizedAccounts(
+      mainAccountAddress,
+    );
+
+    assert.equal(accounts[0].permissions.length, 1);
+    assert.equal(
+      accounts[0].permissions[0].permission,
+      BigInt(permissionList[0]),
+    );
+    assert.equal(accounts[0].permissions[0].authorizedAt, authorizedAtBlock);
+    assert.equal(
+      accounts[0].permissions[0].unauthorizedAt,
+      expectedUnauthorizedAt,
     );
   });
 


### PR DESCRIPTION
So far, if the `_removePermissions` is called, we always update the permission's `unauthorizedAt` field even when it is already unauthorized. User would accidentally create a valid period between the first `unauthorizedAt` and the new `unauthorizedAt`. This PR is to fix the issue and only update `unauthorizedAt` if the permission is authorized.
